### PR TITLE
Fix the argument parsing issue

### DIFF
--- a/tests/cmdline_tmpl.py
+++ b/tests/cmdline_tmpl.py
@@ -1,0 +1,70 @@
+# Licensed under the Apache License: http://www.apache.org/licenses/LICENSE-2.0
+# For details: https://github.com/gaogaotiantian/viztracer/blob/master/NOTICE.txt
+
+import json
+import os
+import shutil
+import subprocess
+import unittest
+
+
+file_fib = \
+"""
+def fib(n):
+    if n < 2:
+        return 1
+    return fib(n-1) + fib(n-2)
+fib(5)
+"""
+
+
+class CmdlineTmpl(unittest.TestCase):
+    def build_script(self, script):
+        with open("cmdline_test.py", "w") as f:
+            f.write(script)
+
+    def cleanup(self, output_file="result.html"):
+        os.remove("cmdline_test.py")
+        if output_file:
+            if type(output_file) is list:
+                for f in output_file:
+                    os.remove(f)
+            elif type(output_file) is str:
+                if os.path.exists(output_file):
+                    if os.path.isdir(output_file):
+                        shutil.rmtree(output_file)
+                    elif os.path.isfile(output_file):
+                        os.remove(output_file)
+            else:
+                raise Exception("Unexpected output file argument")
+
+    def template(self, 
+                 cmd_list, 
+                 expected_output_file="result.html", 
+                 success=True, 
+                 script=file_fib, 
+                 expected_entries=None, 
+                 cleanup=True):
+        if os.getenv("COVERAGE_RUN"):
+            idx = cmd_list.index("viztracer")
+            cmd_list = ["coverage", "run", "--parallel-mode", "--pylib", "-m"] + cmd_list[idx:]
+
+        self.build_script(script)
+        result = subprocess.run(cmd_list, stdout=subprocess.PIPE)
+        self.assertTrue(success ^ (result.returncode != 0))
+        if expected_output_file:
+            if type(expected_output_file) is list:
+                for f in expected_output_file:
+                    self.assertTrue(os.path.exists(f))
+            elif type(expected_output_file) is str:
+                self.assertTrue(os.path.exists(expected_output_file))
+
+        if expected_entries:
+            assert(type(expected_output_file) is str and expected_output_file.split(".")[-1] == "json")
+            with open(expected_output_file) as f:
+                data = json.load(f)
+                self.assertEqual(len(data["traceEvents"]), expected_entries)
+
+        if cleanup:
+            self.cleanup(output_file=expected_output_file)
+        return result

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -8,16 +8,8 @@ import sys
 import json
 import shutil
 from .util import get_json_file_path
+from .cmdline_tmpl import CmdlineTmpl
 
-
-file_fib = \
-"""
-def fib(n):
-    if n < 2:
-        return 1
-    return fib(n-1) + fib(n-2)
-fib(5)
-"""
 
 file_c_function = \
 """
@@ -74,59 +66,7 @@ unrelated, *a = 1, 2, 3
 """
 
 
-class Tmpl(unittest.TestCase):
-    def build_script(self, script):
-        with open("cmdline_test.py", "w") as f:
-            f.write(script)
-
-    def cleanup(self, output_file="result.html"):
-        os.remove("cmdline_test.py")
-        if output_file:
-            if type(output_file) is list:
-                for f in output_file:
-                    os.remove(f)
-            elif type(output_file) is str:
-                if os.path.exists(output_file):
-                    if os.path.isdir(output_file):
-                        shutil.rmtree(output_file)
-                    elif os.path.isfile(output_file):
-                        os.remove(output_file)
-            else:
-                raise Exception("Unexpected output file argument")
-
-    def template(self, 
-                 cmd_list, 
-                 expected_output_file="result.html", 
-                 success=True, 
-                 script=file_fib, 
-                 expected_entries=None, 
-                 cleanup=True):
-        if os.getenv("COVERAGE_RUN"):
-            idx = cmd_list.index("viztracer")
-            cmd_list = ["coverage", "run", "--parallel-mode", "--pylib", "-m"] + cmd_list[idx:]
-
-        self.build_script(script)
-        result = subprocess.run(cmd_list, stdout=subprocess.PIPE)
-        self.assertTrue(success ^ (result.returncode != 0))
-        if expected_output_file:
-            if type(expected_output_file) is list:
-                for f in expected_output_file:
-                    self.assertTrue(os.path.exists(f))
-            elif type(expected_output_file) is str:
-                self.assertTrue(os.path.exists(expected_output_file))
-
-        if expected_entries:
-            assert(type(expected_output_file) is str and expected_output_file.split(".")[-1] == "json")
-            with open(expected_output_file) as f:
-                data = json.load(f)
-                self.assertEqual(len(data["traceEvents"]), expected_entries)
-
-        if cleanup:
-            self.cleanup(output_file=expected_output_file)
-        return result
-
-
-class TestCommandLineBasic(Tmpl):
+class TestCommandLineBasic(CmdlineTmpl):
     def test_no_file(self):
         result = self.template(["python", "-m", "viztracer"], expected_output_file=None)
         self.assertIn("help", result.stdout.decode("utf8"))
@@ -225,7 +165,7 @@ class TestCommandLineBasic(Tmpl):
         self.template(["viztracer", "no_such_file.py"], success=False, expected_output_file=[])
 
 
-class TestPossibleFailures(Tmpl):
+class TestPossibleFailures(CmdlineTmpl):
     def test_main(self):
         self.template(["python", "-m", "viztracer", "-o", "main.json", "cmdline_test.py"], expected_output_file="main.json", script=file_main, expected_entries=3)
 


### PR DESCRIPTION
Fix #21 
Now the arguments that can't be parsed will be assumed as part of the script
if ```--run``` is used, we filter ```sys.argv``` first and get all the script args out before parsing them, because there might be a conflict between the script args and the viztracer args. 