### PR TITLE
Do not create reference to the whole frame/args

### DIFF
--- a/src/viztracer/modules/snaptrace.h
+++ b/src/viztracer/modules/snaptrace.h
@@ -30,8 +30,18 @@ typedef enum _NodeType {
 struct FEEData {
     PyObject* args;
     PyObject* retval;
-    PyCFunctionObject* cfunc;
-    PyCodeObject* pycode;
+    union {
+        struct {
+            PyObject* m_module;
+            const char* ml_name;
+            const char* tp_name;
+        };
+        struct {
+            PyObject* co_name;
+            PyObject* co_filename;
+            int co_firstlineno;
+        };
+    };
     int type;
     int caller_lineno;
     double dur;

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -156,3 +156,26 @@ class TestIssue42(BaseTmpl):
         tracer.stop()
         tracer.parse()
         self.assertEqual(len(tracer.data["traceEvents"]), 0)
+
+
+issue47_code = \
+"""
+import sys
+import gc
+class C:
+    def __init__(self):
+        self.data = bytearray()
+
+    def change(self):
+        b = memoryview(self.data).tobytes()
+        self.data += b"123123"
+        del self.data[:1]
+
+c = C()
+c.change()
+"""
+
+
+class TestIssue47(CmdlineTmpl):
+    def test_issue47(self):
+        self.template(["viztracer", "cmdline_test.py", "-o", "result.json"], script=issue47_code, expected_output_file="result.json", expected_entries=7)


### PR DESCRIPTION
This is to fix issue47, tornado has some non-ideal code that an
extra reference to the local variable will break the whole thing.

It might be a good idea for viztracer to do this anyway.