### PR TITLE
Change the hook for multithread. 

### DIFF
--- a/tests/base_tmpl.py
+++ b/tests/base_tmpl.py
@@ -1,4 +1,5 @@
 from unittest import TestCase
+import gc
 
 
 class BaseTmpl(TestCase):
@@ -7,6 +8,7 @@ class BaseTmpl(TestCase):
 
     def tearDown(self):
         print("{} finish".format(self.id()))
+        gc.collect()
 
     def assertEventNumber(self, data, expected_entries):
         entries = len([1 for entry in data["traceEvents"] if entry["ph"] != "M"])

--- a/tests/test_multithread.py
+++ b/tests/test_multithread.py
@@ -5,6 +5,7 @@ from viztracer import VizTracer
 import time
 import threading
 from .base_tmpl import BaseTmpl
+from .cmdline_tmpl import CmdlineTmpl
 
 
 def fib(n):
@@ -69,3 +70,36 @@ class TestMultithread(BaseTmpl):
         tracer.stop()
         entries = tracer.parse()
         self.assertEqual(entries, 300)
+
+
+file_log_sparse = """
+import threading
+from viztracer import log_sparse
+
+class MyThreadSparse(threading.Thread):
+    def run(self):
+        self.sparse_func()
+
+    @log_sparse
+    def sparse_func(self):
+        return 0
+
+thread1 = MyThreadSparse()
+thread2 = MyThreadSparse()
+
+thread1.start()
+thread2.start()
+
+threads = [thread1, thread2]
+
+for thread in threads:
+    thread.join()
+"""
+
+
+class TestMultithreadCmdline(CmdlineTmpl):
+    def test_with_log_sparse(self):
+        self.template(["viztracer", "-o", "result.json", "--log_sparse", "cmdline_test.py"],
+                      expected_output_file="result.json",
+                      script=file_log_sparse,
+                      expected_entries=2)

--- a/tests/test_tracer.py
+++ b/tests/test_tracer.py
@@ -217,6 +217,8 @@ class TestTracerFeature(BaseTmpl):
     def test_log_gc(self):
         import gc
         tracer = _VizTracer(log_gc=True)
+        # do collect first to get rid of the garbage tracer
+        gc.collect()
         self.assertTrue(tracer.log_gc)
         tracer.start()
         gc.collect()


### PR DESCRIPTION
Now multithread will always
have a dummy profile function, so we can enable/disable the
profiling anytime we want.

The downside is, as we will only remove the profile function
when viztracer is deallocated, it's possible that the timing of
garbage collection affects the behavior of viztracer. This won't
be a problem if there is only one tracer per process. However,
for tests it's not the case. We need to enforce a garbage
collection after each test.

This fix part of #72 when a spawned thread can't find thread
specific info without triggering profile function