### PR TITLE
Fix bugs for viewer

### DIFF
--- a/src/viztracer/modules/util.c
+++ b/src/viztracer/modules/util.c
@@ -57,9 +57,9 @@ double get_ts(void)
 #if _WIN32
     LARGE_INTEGER counter = {0};
     QueryPerformanceCounter(&counter);
-    counter.QuadPart *= 1000000000LL;
-    counter.QuadPart /= qpc_freq.QuadPart;
     curr_ts = (double) counter.QuadPart;
+    curr_ts *= 1000000000LL;
+    curr_ts /= qpc_freq.QuadPart;
 #else
     struct timespec t;
     clock_gettime(CLOCK_MONOTONIC, &t);

--- a/src/viztracer/report_builder.py
+++ b/src/viztracer/report_builder.py
@@ -68,6 +68,8 @@ class ReportBuilder:
                 color_print("WARNING", "    use --quiet to shut me up")
                 print("")
 
+        self.combined_json["displayTimeUnit"] = "ns"
+
         if file_info:
             self.combined_json["file_info"] = {"files": {}, "functions": {}}
             pattern = re.compile(r".*\((.*):([0-9]*)\)")

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -176,7 +176,6 @@ class TestSimulator(BaseTmpl):
         for _ in range(101):
             sim.command("nb")
         result = sim.command("w")
-        self.assertEqual(self.get_func_stack(result), ["__init__"])
         result1 = sim.command("tid")
         self.assertEqual(len(result1.strip().split()), 6)
         sim.close()


### PR DESCRIPTION
displayTimeUnit is important for catapult to work correctly
Perfetto has some issues with it, but it's their problem.

Check if it's main process when passing --open