### PR TITLE
Make vizviewer command easy to copy and paste

### DIFF
--- a/src/viztracer/report_builder.py
+++ b/src/viztracer/report_builder.py
@@ -168,7 +168,6 @@ class ReportBuilder:
             self.generate_report(output_file, output_format="json", file_info=file_info)
 
         if self.verbose > 0 and isinstance(output_file, str):
-            print("Saving report to {} ...".format(os.path.abspath(output_file)))
-            print('Use', end=" ")
-            color_print("OKGREEN", '"vizviewer <your_report>"', end=" ")
-            print('to open the report')
+            report_abspath = os.path.abspath(output_file)
+            print("Use the following command to open the report:")
+            color_print("OKGREEN", "vizviewer {}".format(report_abspath))


### PR DESCRIPTION
Small usability improvement to make it faster / more convenient to open generated report file by copy pasting a single line in one go in the terminal.