### PR TITLE
Stabilize tests to have fewer random errors

### DIFF
--- a/src/viztracer/viztracer.py
+++ b/src/viztracer/viztracer.py
@@ -242,6 +242,13 @@ class VizTracer(_VizTracer):
         self.cwd = os.getcwd()
 
         def term_handler(sig, frame):
+            while frame is not None:
+                if frame.f_code.co_name == "_run_finalizers":
+                    # If we are already in _run_finalizers, we are exiting now
+                    # To avoid messing up with the exit function, do nothing
+                    # here.
+                    return  # pragma: no cover
+                frame = frame.f_back
             sys.exit(0)
 
         signal.signal(signal.SIGTERM, term_handler)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -180,7 +180,7 @@ class TestDecorator(BaseTmpl):
 
         with tempfile.TemporaryDirectory() as tmp_dir:
 
-            @trace_and_save(output_dir=tmp_dir)
+            @trace_and_save(output_dir=os.path.join(tmp_dir, "new_dir"))
             def cover_mkdir():
                 return
 
@@ -188,7 +188,7 @@ class TestDecorator(BaseTmpl):
             time.sleep(1)
 
             def t():
-                self.assertEqual(len(os.listdir(tmp_dir)), 1)
+                self.assertEqual(len(os.listdir(os.path.join(tmp_dir, "new_dir"))), 1)
 
             self.assertTrueTimeout(t, 10)
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -163,26 +163,32 @@ class TestDecorator(BaseTmpl):
 
     def test_trace_and_save(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
-            tmp_dir1 = os.path.join(tmp_dir, "tmp1")
-            tmp_dir2 = os.path.join(tmp_dir, "tmp2")
 
-            @trace_and_save(output_dir=tmp_dir1)
+            @trace_and_save(output_dir=tmp_dir)
             def my_function(n):
                 fib(n)
-
-            @trace_and_save(output_dir=tmp_dir2)
-            def cover_mkdir():
-                return
 
             for _ in range(5):
                 my_function(10)
 
-            cover_mkdir()
-            time.sleep(1.5)
+            time.sleep(1)
 
             def t():
-                self.assertEqual(len(os.listdir(tmp_dir1)), 5)
-                self.assertEqual(len(os.listdir(tmp_dir2)), 1)
+                self.assertEqual(len(os.listdir(tmp_dir)), 5)
+
+            self.assertTrueTimeout(t, 10)
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+
+            @trace_and_save(output_dir=tmp_dir)
+            def cover_mkdir():
+                return
+
+            cover_mkdir()
+            time.sleep(1)
+
+            def t():
+                self.assertEqual(len(os.listdir(tmp_dir)), 1)
 
             self.assertTrueTimeout(t, 10)
 

--- a/tests/test_logsparse.py
+++ b/tests/test_logsparse.py
@@ -30,7 +30,7 @@ def f(x):
     return x*x
 
 if __name__ == "__main__":
-    process_num = 5
+    process_num = 2
     with Pool(processes=process_num) as pool:
         print(pool.map(f, range(10)))
 

--- a/tests/test_multiprocess.py
+++ b/tests/test_multiprocess.py
@@ -117,7 +117,7 @@ def f(x):
     return x*x
 
 if __name__ == "__main__":
-    process_num = 5
+    process_num = 2
     with Pool(processes=process_num) as pool:
         print(pool.map(f, range(10)))
 


### PR DESCRIPTION
Ignore SIGTERM if already cleaning up