### PR TITLE
Use utf-8 for viewer encoding

### DIFF
--- a/src/viztracer/viewer.py
+++ b/src/viztracer/viewer.py
@@ -109,7 +109,7 @@ def view(
     Handler: Callable[..., HttpHandler]
     if flamegraph:
         if filename.endswith("json"):
-            with open(filename) as f:
+            with open(filename, encoding="utf-8", errors="ignore") as f:
                 trace_data = json.load(f)
             fg = FlameGraph(trace_data)
             fg_data = fg.dump_to_perfetto()
@@ -119,9 +119,10 @@ def view(
             return 1
     elif filename.endswith("json"):
         trace_data = None
-        with open(filename) as f:
+        with open(filename, encoding="utf-8", errors="ignore") as f:
             trace_data = json.load(f)
             file_info = trace_data.get("file_info", {})
+            print(file_info)
         Handler = functools.partial(PerfettoHandler, file_info, path, None)
     elif filename.endswith("html"):
         Handler = functools.partial(HtmlHandler, path)

--- a/src/viztracer/viewer.py
+++ b/src/viztracer/viewer.py
@@ -122,7 +122,6 @@ def view(
         with open(filename, encoding="utf-8", errors="ignore") as f:
             trace_data = json.load(f)
             file_info = trace_data.get("file_info", {})
-            print(file_info)
         Handler = functools.partial(PerfettoHandler, file_info, path, None)
     elif filename.endswith("html"):
         Handler = functools.partial(HtmlHandler, path)


### PR DESCRIPTION
The json file is always encoded in utf-8. Ignore the errors to avoid frustrating users