### PR TITLE
Fixed help command line options by disabling help in a previous parser

### DIFF
--- a/src/viztracer/main.py
+++ b/src/viztracer/main.py
@@ -183,7 +183,7 @@ class VizUI:
         elif "--run" in argv[1:]:
             idx = argv.index("--run")
 
-        rcfile_parser = argparse.ArgumentParser()
+        rcfile_parser = argparse.ArgumentParser(add_help=False)
         rcfile_parser.add_argument("--rcfile", nargs="?", default=".viztracerrc")
         rc_options, _ = rcfile_parser.parse_known_args(argv[1:])
         default_namespace = self.load_config_file(rc_options.rcfile)

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -164,8 +164,22 @@ loop.close()
 
 class TestCommandLineBasic(CmdlineTmpl):
     def test_no_file(self):
-        result = self.template(["python", "-m", "viztracer"], expected_output_file=None)
-        self.assertIn("help", result.stdout.decode("utf8"))
+        result = self.template(["python", "-m", "viztracer"], expected_output_file=None).stdout.decode("utf8")
+        self.assertIn("help", result)
+        #  Check for a few more arguments to ensure we hit the intended argumentParser
+        self.assertIn("--output_file", result)
+        self.assertIn("--log_async", result)
+        self.assertIn("--attach", result)
+        self.assertIn("--plugins", result)
+        self.assertIn("--rcfile", result)
+
+    def test_help(self):
+        """Test that all three options print the same help page"""
+        result = self.template(["python", "-m", "viztracer"], expected_output_file=None).stdout.decode("utf-8")
+        result_h = self.template(["python", "-m", "viztracer", "-h"], expected_output_file=None).stdout.decode("utf-8")
+        result_help = self.template(["python", "-m", "viztracer", "--help"], expected_output_file=None).stdout.decode("utf-8")
+        self.assertEqual(result_h, result_help)
+        self.assertEqual(result, result_h)
 
     def test_run(self):
         self.template(["python", "-m", "viztracer", "cmdline_test.py"])

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -164,22 +164,24 @@ loop.close()
 
 class TestCommandLineBasic(CmdlineTmpl):
     def test_no_file(self):
-        result = self.template(["python", "-m", "viztracer"], expected_output_file=None).stdout.decode("utf8")
-        self.assertIn("help", result)
+        result = self.template(["python", "-m", "viztracer"], expected_output_file=None)
+        result_stdout = result.stdout.decode("utf8")
+        self.assertIn("help", result_stdout)
         #  Check for a few more arguments to ensure we hit the intended argumentParser
-        self.assertIn("--output_file", result)
-        self.assertIn("--log_async", result)
-        self.assertIn("--attach", result)
-        self.assertIn("--plugins", result)
-        self.assertIn("--rcfile", result)
+        self.assertIn("--output_file", result_stdout)
+        self.assertIn("--log_async", result_stdout)
+        self.assertIn("--attach", result_stdout)
+        self.assertIn("--plugins", result_stdout)
+        self.assertIn("--rcfile", result_stdout)
 
     def test_help(self):
         """Test that all three options print the same help page"""
-        result = self.template(["python", "-m", "viztracer"], expected_output_file=None).stdout.decode("utf-8")
-        result_h = self.template(["python", "-m", "viztracer", "-h"], expected_output_file=None).stdout.decode("utf-8")
-        result_help = self.template(["python", "-m", "viztracer", "--help"], expected_output_file=None).stdout.decode("utf-8")
-        self.assertEqual(result_h, result_help)
-        self.assertEqual(result, result_h)
+        result = self.template(["python", "-m", "viztracer"], expected_output_file=None)
+        result_h = self.template(["python", "-m", "viztracer", "-h"], expected_output_file=None)
+        result_help = self.template(["python", "-m", "viztracer", "--help"], expected_output_file=None)
+
+        self.assertEqual(result_h.stdout.decode("utf-8"), result_help.stdout.decode("utf-8"))
+        self.assertEqual(result.stdout.decode("utf-8"), result_h.stdout.decode("utf-8"))
 
     def test_run(self):
         self.template(["python", "-m", "viztracer", "cmdline_test.py"])


### PR DESCRIPTION
Fix for https://github.com/gaogaotiantian/viztracer/issues/193