### PR TITLE
Always include Python.h before all other header files

### DIFF
--- a/src/viztracer/modules/snaptrace.c
+++ b/src/viztracer/modules/snaptrace.c
@@ -2,8 +2,8 @@
 // For details: https://github.com/gaogaotiantian/viztracer/blob/master/NOTICE.txt
 
 #define PY_SSIZE_T_CLEAN
-#include <stdlib.h>
 #include <Python.h>
+#include <stdlib.h>
 #include <frameobject.h>
 #include <time.h>
 #if _WIN32


### PR DESCRIPTION
This is required in https://docs.python.org/3/c-api/intro.html