### PR TITLE
Make viztracer thread-safe without the GIL

### DIFF
--- a/src/viztracer/modules/snaptrace.c
+++ b/src/viztracer/modules/snaptrace.c
@@ -63,9 +63,16 @@ LARGE_INTEGER qpc_freq;
 #endif
 
 #ifdef Py_NOGIL
+// The "nogil" implementation of SNAPTRACE_THREAD_PROTECT_START/END uses
+// a per-tracer mutex. The mutex is acquired in SNAPTRACE_THREAD_PROTECT_START
+// and released in SNAPTRACE_THREAD_PROTECT_END.
+// NOTE: these macros delimit a C scope so any variables accessed after
+// a SNAPTRACE_THREAD_PROTECT_END need to be declared before
+// SNAPTRACE_THREAD_PROTECT_START.
 #define SNAPTRACE_THREAD_PROTECT_START(self) Py_BEGIN_CRITICAL_SECTION(&self->mutex)
 #define SNAPTRACE_THREAD_PROTECT_END(self) Py_END_CRITICAL_SECTION
 #else
+// The default implementation is a no-op.
 #define SNAPTRACE_THREAD_PROTECT_START(self)
 #define SNAPTRACE_THREAD_PROTECT_END(self)
 #endif

--- a/src/viztracer/modules/snaptrace.c
+++ b/src/viztracer/modules/snaptrace.c
@@ -597,6 +597,8 @@ static PyObject*
 snaptrace_load(TracerObject* self, PyObject* args)
 {
     PyObject* lst = PyList_New(0);
+
+    SNAPTRACE_THREAD_PROTECT_START(self);
     struct EventNode* curr = self->buffer + self->buffer_head_idx;
     PyObject* pid = NULL;
     PyObject* cat_fee = PyUnicode_FromString("FEE");
@@ -612,8 +614,6 @@ snaptrace_load(TracerObject* self, PyObject* args)
     struct MetadataNode* metadata_node = NULL;
     PyObject* task_dict = NULL;
     PyObject* func_name_dict = PyDict_New();
-
-    SNAPTRACE_THREAD_PROTECT_START(self);
 
     if (self->fix_pid > 0) {
         pid = PyLong_FromLong(self->fix_pid);

--- a/src/viztracer/modules/snaptrace.h
+++ b/src/viztracer/modules/snaptrace.h
@@ -77,6 +77,9 @@ typedef struct {
     long buffer_size;
     long buffer_head_idx;
     long buffer_tail_idx;
+#ifdef Py_NOGIL
+    PyMutex mutex;
+#endif
     struct MetadataNode* metadata_head;
 } TracerObject;
 

--- a/tests/test_multithread.py
+++ b/tests/test_multithread.py
@@ -48,7 +48,7 @@ class TestMultithread(BaseTmpl):
 
         tracer.stop()
         entries = tracer.parse()
-        self.assertGreater(entries, 180)
+        self.assertGreater(entries, 170)
 
         metadata = [e for e in tracer.data["traceEvents"] if e["ph"] == "M"]
         self.assertEqual(len([e for e in metadata if e["name"] == "process_name"]), 1)


### PR DESCRIPTION
This adds a per-Tracer lock for nogil Python that protects the shared
event node buffer and the metadata linked list.

The event count in the multithread test is also relaxed a bit, due to a 
different number of function calls during thread joining in nogil Python.