### PR TITLE
Make the targets phony

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+.PHONY: refresh build install build_dist json release lint test clean
+
 refresh: clean build install lint
 
 build:


### PR DESCRIPTION
If a file named for example `clean` is ever created in the directory: since it has no prerequisites, the file `clean` would always be considered up to date and the `rm` commands under the target `clean` would not be executed.

To avoid this problem, we need to make the targets [phony](https://www.gnu.org/software/make/manual/html_node/Phony-Targets.html).