### PR TITLE
VCompressor Benchmark

### DIFF
--- a/tests/test_vcompressor.py
+++ b/tests/test_vcompressor.py
@@ -2,18 +2,18 @@
 # For details: https://github.com/gaogaotiantian/viztracer/blob/master/NOTICE.txt
 
 
-import os
 import logging
-import tempfile
 import lzma
-from shutil import copyfileobj
-from typing import List, Callable, Optional, Tuple, overload
+import os
+import tempfile
 from collections import namedtuple
 from functools import wraps
+from shutil import copyfileobj
+from typing import Callable, List, Optional, Tuple, overload
 
 from .cmdline_tmpl import CmdlineTmpl
-from .util import get_json_file_path
 from .test_performance import Timer
+from .util import get_json_file_path
 
 
 class TestVCompressor(CmdlineTmpl):
@@ -86,7 +86,7 @@ class TestVCompressorPerformance(CmdlineTmpl):
         return f"{filesize:8.2f}B"
 
     @classmethod
-    def _print_cr_result(
+    def _print_result(
         cls,
         filename: str,
         original_size: int,
@@ -148,10 +148,11 @@ class TestVCompressorPerformance(CmdlineTmpl):
         for subtest_idx, filename in enumerate(testcases_filename, start=1):
             path = get_json_file_path(filename)
             original_size = os.path.getsize(path)
-            other_results = [                             # More compressor can be added here
+            # More compressors can be added here
+            other_results = [
                 ("LZMA", self._benchmark_lzma(path)),
             ]
             with self.subTest(testcase=filename):
                 vcompress_result = self._benchmark_vcompressor(path)
-                self._print_cr_result(filename, original_size,
-                                      vcompress_result, other_results, subtest_idx=subtest_idx)
+                self._print_result(filename, original_size,
+                                   vcompress_result, other_results, subtest_idx=subtest_idx)

--- a/tests/test_vcompressor.py
+++ b/tests/test_vcompressor.py
@@ -7,7 +7,7 @@ import logging
 import tempfile
 import lzma
 from shutil import copyfileobj
-from typing import Callable, Optional
+from typing import Callable, Optional, overload
 from collections import namedtuple
 from functools import wraps
 
@@ -35,25 +35,47 @@ class TestVCompressor(CmdlineTmpl):
 BenchmarkResult = namedtuple("BenchmarkResult", ["file_size", "elapsed_time"])  # unit: byte, second
 
 
-def _benchmark(benchmark_process: Callable[[str, str], None],  # func(uncompressed_file_path, compressed_file_path)
-               loop_time: int = 3) -> Callable[[str], BenchmarkResult]:
-    @wraps(benchmark_process)
-    def _wrapper(self, uncompressed_file_path: str) -> BenchmarkResult:
-        compression_time_total = 0.
-        with tempfile.TemporaryDirectory() as tmpdir:
-            compressed_file_path = os.path.join(tmpdir, "result.compressed")
-            # pre-warm
-            benchmark_process(self, uncompressed_file_path, compressed_file_path)
-            os.remove(compressed_file_path)
-            # real benchmark
-            for _ in range(loop_time):
-                with Timer() as t:
-                    benchmark_process(self, uncompressed_file_path, compressed_file_path)
-                    compression_time_total += t.get_time()
-                compressed_file_size = os.path.getsize(compressed_file_path)
+@overload
+def _benchmark(benchmark_process: Callable[..., None]):
+    ...
+
+
+@overload
+def _benchmark(repeat: int):
+    ...
+
+
+def _benchmark(*args, **kargs):
+    def _decorator(benchmark_process: Callable) -> Callable:
+        @wraps(benchmark_process)
+        def _wrapper(self, uncompressed_file_path: str) -> BenchmarkResult:
+            compression_time_total = 0.
+            with tempfile.TemporaryDirectory() as tmpdir:
+                compressed_file_path = os.path.join(tmpdir, "result.compressed")
+                # pre-warm
+                benchmark_process(self, uncompressed_file_path, compressed_file_path)
                 os.remove(compressed_file_path)
-        return BenchmarkResult(compressed_file_size, compression_time_total / loop_time)
-    return _wrapper
+                # real benchmark
+                for _ in range(loop_time):
+                    with Timer() as t:
+                        benchmark_process(self, uncompressed_file_path, compressed_file_path)
+                        compression_time_total += t.get_time()
+                    compressed_file_size = os.path.getsize(compressed_file_path)
+                    os.remove(compressed_file_path)
+            return BenchmarkResult(compressed_file_size, compression_time_total / loop_time)
+        return _wrapper
+
+    if len(args) == 0 and len(kargs) == 0:
+        raise TypeError("_benchmark must decorate a function.")
+
+    # used as @_benchmark
+    if len(args) == 1 and len(kargs) == 0 and callable(args[0]):
+        loop_time = 3
+        return _decorator(args[0])
+
+    # used as @_benchmark(...)
+    loop_time = kargs["repeat"] if "repeat" in kargs else args[0]
+    return _decorator
 
 
 class TestVCompressorPerformance(CmdlineTmpl):

--- a/tests/test_vcompressor.py
+++ b/tests/test_vcompressor.py
@@ -80,7 +80,7 @@ class TestVCompressorPerformance(CmdlineTmpl):
 
     def test_benchmark_basic(self):
         # More testcases can be added here
-        testcases_filename = ["vdb_basic.json", "multithread.json", "vdb_multithread.json"]
+        testcases_filename = ["vdb_basic.json", "multithread.json"]
 
         for subtest_idx, filename in enumerate(testcases_filename, start=1):
             path = get_json_file_path(filename)

--- a/tests/test_vcompressor.py
+++ b/tests/test_vcompressor.py
@@ -3,7 +3,11 @@
 
 
 import os
+import logging
 import tempfile
+import lzma
+from shutil import copyfileobj
+from typing import Optional
 
 from .cmdline_tmpl import CmdlineTmpl
 from .util import get_json_file_path
@@ -23,3 +27,65 @@ class TestVCompressor(CmdlineTmpl):
                 ["viztracer", "-o", dup_json_path, "--decompress", cvf_path],
                 expected_output_file=dup_json_path
             )
+
+
+class TestVCompressorPerformance(CmdlineTmpl):
+
+    def _human_readable_filesize(self, filesize: int) -> str:
+        units = [("PB", 1 << 50), ("TB", 1 << 40), ("GB", 1 << 30), ("MB", 1 << 20), ("KB", 1 << 10), ("B", 1)]
+        for unit_name, unit_base in units:
+            norm_size = filesize / unit_base
+            if norm_size >= 0.8:
+                return "{:8.2f}{}".format(norm_size, unit_name)
+
+    def _print_cr_result(self,
+                         filename: str,
+                         original_size: int,
+                         baseline_size: int,
+                         vcompressor_size: int,
+                         baseline_name: str = "LZMA",
+                         subtest_idx: Optional[int] = None):
+        if subtest_idx is None:
+            logging.info("On file \"{}\":".format(filename))
+        else:
+            logging.info("{}. On file \"{}\":".format(subtest_idx, filename))
+        logging.info("    [Space] ({} as baseline)".format(baseline_name))
+        logging.info("      Original:    {}".format(self._human_readable_filesize(original_size)))
+        logging.info("      Baseline:    {}(1.00)".format(self._human_readable_filesize(baseline_size)))
+        logging.info("      VCompressor: {}({:.2f})".format(self._human_readable_filesize(vcompressor_size),
+                                                            vcompressor_size / baseline_size))
+
+    def get_filesize_vcompressor(self, original_file_path: str) -> int:
+        '''Use the demo file to get the file size (in bytes) after VCompressor compression.'''
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            compressed_file_path = os.path.join(tmpdir, "result.cvf")
+            self.template(
+                ["viztracer", "-o", compressed_file_path, "--compress", original_file_path],
+                expected_output_file=compressed_file_path, cleanup=False
+            )
+            compressed_file_size = os.path.getsize(compressed_file_path)
+        return compressed_file_size
+
+    def get_filesize_lzma(self, original_file_path: str, compression_level: int = lzma.PRESET_DEFAULT) -> int:
+        '''Use the demo file to get the file size (in bytes) after lzma compression, as a baseline.'''
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            compressed_file_path = os.path.join(tmpdir, "result.xz")
+            with open(original_file_path, "rb") as original_file, \
+                 lzma.open(compressed_file_path, "wb", preset=compression_level) as compressed_file:
+                copyfileobj(original_file, compressed_file)
+            compressed_file_size = os.path.getsize(compressed_file_path)
+        return compressed_file_size
+
+    def test_benchmark_basic(self):
+        # More testcases can be added here
+        testcases_filename = ["vdb_basic.json", "multithread.json", "vdb_multithread.json"]
+
+        for subtest_idx, filename in enumerate(testcases_filename, start=1):
+            path = get_json_file_path(filename)
+            original_size = os.path.getsize(path)
+            baseline_size = self.get_filesize_lzma(path)
+            with self.subTest(testcase=filename):
+                vcompress_size = self.get_filesize_vcompressor(path)
+                self._print_cr_result(filename, original_size, baseline_size, vcompress_size, subtest_idx=subtest_idx)

--- a/tests/test_vcompressor.py
+++ b/tests/test_vcompressor.py
@@ -32,53 +32,49 @@ class TestVCompressor(CmdlineTmpl):
             )
 
 
-BenchmarkResult = namedtuple("BenchmarkResult", ["file_size", "elapsed_time"])  # unit: byte, second
-
-
-@overload
-def _benchmark(benchmark_process: Callable[..., None]):
-    ...
-
-
-@overload
-def _benchmark(repeat: int):
-    ...
-
-
-def _benchmark(*args, **kargs):
-    def _decorator(benchmark_process: Callable) -> Callable:
-        @wraps(benchmark_process)
-        def _wrapper(self, uncompressed_file_path: str) -> BenchmarkResult:
-            compression_time_total = 0.
-            with tempfile.TemporaryDirectory() as tmpdir:
-                compressed_file_path = os.path.join(tmpdir, "result.compressed")
-                # pre-warm
-                benchmark_process(self, uncompressed_file_path, compressed_file_path)
-                os.remove(compressed_file_path)
-                # real benchmark
-                for _ in range(loop_time):
-                    with Timer() as t:
-                        benchmark_process(self, uncompressed_file_path, compressed_file_path)
-                        compression_time_total += t.get_time()
-                    compressed_file_size = os.path.getsize(compressed_file_path)
-                    os.remove(compressed_file_path)
-            return BenchmarkResult(compressed_file_size, compression_time_total / loop_time)
-        return _wrapper
-
-    if len(args) == 0 and len(kargs) == 0:
-        raise TypeError("_benchmark must decorate a function.")
-
-    # used as @_benchmark
-    if len(args) == 1 and len(kargs) == 0 and callable(args[0]):
-        loop_time = 3
-        return _decorator(args[0])
-
-    # used as @_benchmark(...)
-    loop_time = kargs["repeat"] if "repeat" in kargs else args[0]
-    return _decorator
-
-
 class TestVCompressorPerformance(CmdlineTmpl):
+
+    BenchmarkResult = namedtuple("BenchmarkResult", ["file_size", "elapsed_time"])  # unit: byte, second
+
+    @overload
+    def _benchmark(benchmark_process: Callable[..., None]):
+        ...
+
+    @overload
+    def _benchmark(repeat: int):
+        ...
+
+    def _benchmark(*args, **kargs):
+        def _decorator(benchmark_process: Callable) -> Callable:
+            @wraps(benchmark_process)
+            def _wrapper(self, uncompressed_file_path: str) -> "TestVCompressorPerformance.BenchmarkResult":
+                compression_time_total = 0.
+                with tempfile.TemporaryDirectory() as tmpdir:
+                    compressed_file_path = os.path.join(tmpdir, "result.compressed")
+                    # pre-warm
+                    benchmark_process(self, uncompressed_file_path, compressed_file_path)
+                    os.remove(compressed_file_path)
+                    # real benchmark
+                    for _ in range(loop_time):
+                        with Timer() as t:
+                            benchmark_process(self, uncompressed_file_path, compressed_file_path)
+                            compression_time_total += t.get_time()
+                        compressed_file_size = os.path.getsize(compressed_file_path)
+                        os.remove(compressed_file_path)
+                return TestVCompressorPerformance.BenchmarkResult(compressed_file_size, compression_time_total / loop_time)
+            return _wrapper
+
+        if len(args) == 0 and len(kargs) == 0:
+            raise TypeError("_benchmark must decorate a function.")
+
+        # used as @_benchmark
+        if len(args) == 1 and len(kargs) == 0 and callable(args[0]):
+            loop_time = 3
+            return _decorator(args[0])
+
+        # used as @_benchmark(...)
+        loop_time = kargs["repeat"] if "repeat" in kargs else args[0]
+        return _decorator
 
     @staticmethod
     def _human_readable_filesize(filesize: int) -> str:  # filesize in bytes

--- a/tests/test_vcompressor.py
+++ b/tests/test_vcompressor.py
@@ -52,9 +52,12 @@ class TestVCompressorPerformance(CmdlineTmpl):
             logging.info("{}. On file \"{}\":".format(subtest_idx, filename))
         logging.info("    [Space] ({} as baseline)".format(baseline_name))
         logging.info("      Uncompressed: {}".format(self._human_readable_filesize(original_size)))
-        logging.info("      Baseline:    {}(1.00)".format(self._human_readable_filesize(baseline_size)))
-        logging.info("      VCompressor: {}({:.2f})".format(self._human_readable_filesize(vcompressor_size),
-                                                            vcompressor_size / baseline_size))
+        # Here, CR stands for compress ratio.
+        logging.info("      Baseline:     {}(1.00) [CR:{:6.2f}%]".format(self._human_readable_filesize(baseline_size),
+                                                                         baseline_size / original_size * 100))
+        logging.info("      VCompressor:  {}({:.2f}) [CR:{:6.2f}%]".format(self._human_readable_filesize(vcompressor_size),
+                                                                           vcompressor_size / baseline_size,
+                                                                           vcompressor_size / original_size * 100))
 
     def get_filesize_vcompressor(self, original_file_path: str) -> int:
         '''Use the demo file to get the file size (in bytes) after VCompressor compression.'''

--- a/tests/test_vcompressor.py
+++ b/tests/test_vcompressor.py
@@ -32,11 +32,12 @@ class TestVCompressor(CmdlineTmpl):
 class TestVCompressorPerformance(CmdlineTmpl):
 
     def _human_readable_filesize(self, filesize: int) -> str:
-        units = [("PB", 1 << 50), ("TB", 1 << 40), ("GB", 1 << 30), ("MB", 1 << 20), ("KB", 1 << 10), ("B", 1)]
+        units = [("PB", 1 << 50), ("TB", 1 << 40), ("GB", 1 << 30), ("MB", 1 << 20), ("KB", 1 << 10)]
         for unit_name, unit_base in units:
             norm_size = filesize / unit_base
             if norm_size >= 0.8:
                 return "{:8.2f}{}".format(norm_size, unit_name)
+        return "{:8.2f}B".format(filesize)
 
     def _print_cr_result(self,
                          filename: str,

--- a/tests/test_vcompressor.py
+++ b/tests/test_vcompressor.py
@@ -51,7 +51,7 @@ class TestVCompressorPerformance(CmdlineTmpl):
         else:
             logging.info("{}. On file \"{}\":".format(subtest_idx, filename))
         logging.info("    [Space] ({} as baseline)".format(baseline_name))
-        logging.info("      Original:    {}".format(self._human_readable_filesize(original_size)))
+        logging.info("      Uncompressed: {}".format(self._human_readable_filesize(original_size)))
         logging.info("      Baseline:    {}(1.00)".format(self._human_readable_filesize(baseline_size)))
         logging.info("      VCompressor: {}({:.2f})".format(self._human_readable_filesize(vcompressor_size),
                                                             vcompressor_size / baseline_size))


### PR DESCRIPTION
As #249 mentioned, VCompressor is designed for a decent compress ratio. Here provides a benchmark framework to easily calculate performance improvement space-wise and time-wise on specific test cases.

Note: Here, I chose to use LZMA, famous for its high compress ratio on average files, as a baseline in terms of space-wise benchmark.

---

**Main Features**:
- [x] Space-wise Benchmark
- [x] Time-wise Benchmark
- [x] Display compress ratio in the vcompressor benchmark
- [x] Support multiple other compressors for comparison

**Other Important Change Log**:
- [x] FIX: custom `repeat`(previously `loop_time`) in `_benchmark` is now implemented correctly
- [x] STYLE: All related functions and types are now placed in a single class, without affecting global namespace

---
**Output Example of this Benchmark Test**:
```
2022-09-05 23:01:24,684 INFO: tests.test_vcompressor.TestVCompressorPerformance.test_benchmark_basic start
2022-09-05 23:01:26,302 INFO: 1. On file "vdb_basic.json":
2022-09-05 23:01:26,302 INFO:     [Space]
2022-09-05 23:01:26,302 INFO:       Uncompressed:       2.95KB
2022-09-05 23:01:26,302 INFO:       VCompressor:      531.00B(1.000) [CR: 17.57%]
2022-09-05 23:01:26,302 INFO:       LZMA:             504.00B(0.949) [CR: 16.68%]
2022-09-05 23:01:26,303 INFO:     [Time]
2022-09-05 23:01:26,303 INFO:       VCompressor:        0.405s(1.000)
2022-09-05 23:01:26,303 INFO:       LZMA:               0.004s(0.010)
2022-09-05 23:01:27,757 INFO: 2. On file "multithread.json":
2022-09-05 23:01:27,757 INFO:     [Space]
2022-09-05 23:01:27,757 INFO:       Uncompressed:     105.22KB
2022-09-05 23:01:27,757 INFO:       VCompressor:        9.05KB(1.000) [CR:  8.60%]
2022-09-05 23:01:27,757 INFO:       LZMA:              16.66KB(1.840) [CR: 15.83%]
2022-09-05 23:01:27,757 INFO:     [Time]
2022-09-05 23:01:27,757 INFO:       VCompressor:        0.330s(1.000)
2022-09-05 23:01:27,757 INFO:       LZMA:               0.023s(0.071)
2022-09-05 23:01:27,757 INFO: tests.test_vcompressor.TestVCompressorPerformance.test_benchmark_basic finish
```