### PR TITLE
Fix a bug on the decompressor

### DIFF
--- a/src/viztracer/modules/vcompressor/README.md
+++ b/src/viztracer/modules/vcompressor/README.md
@@ -32,7 +32,7 @@ header(header) - pid(pid) - tid(tid) - name(str)
 
 ### FEE
 
-header(header) - pid(pid) - tid(pid) - name(str) - count(uint64) - [start(ts) - dur(ts)]*
+header(header) - pid(pid) - tid(tid) - name(str) - count(uint64) - [start(ts) - dur(ts)]*
 
 ### File info
 

--- a/src/viztracer/modules/vcompressor/vcompressor.c
+++ b/src/viztracer/modules/vcompressor/vcompressor.c
@@ -212,7 +212,7 @@ vcompressor_decompress(VcompressorObject* self, PyObject* args) {
         return NULL;
     }
 
-    fptr = fopen(filename, "r");
+    fptr = fopen(filename, "rb");
     if (!fptr) {
         PyErr_Format(PyExc_ValueError, "Can't open file %s to write", filename);
         goto clean_exit;


### PR DESCRIPTION
In the Vcompressor.c, the decompressor part use `fptr = fopen(filename, "r");` to open the binary file. But if a hexadecimal number "**1A**" in the binary file, this will be considered as the end of the document. Once `fread()` found a "1A", it will stop reading and return a zero, which will cause the program to think the file is corrupt. Use `fptr = fopen(filename, "rb");`  will  treat the "1A" as a normal number. It makes the program pass the test.

But when I run `viztracer -o result.json --decompress .\resulead.jsont.cvf`, The program will show
`wrong header 0
wrong header 0
wrong header 0
wrong header 0`. 
I will try to figure out why this is happening later