### PR TITLE
Fix test viewer

### DIFF
--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -421,8 +421,14 @@ class TestViewer(CmdlineTmpl):
                     time.sleep(0.02)
                     resp = urllib.request.urlopen(f"{v.url()}/{i}.json")
                     self.assertEqual(resp.code, 200)
-                    port = str(v.port)
-                    self.assertRegex(resp.url, f"http://127.0.0.1:{port[:-2]}[{port[-2]}-{int(port[-2])+1}][0-9]/")
+
+                    def _extract_port(u: str) -> int:
+                        pattern = re.compile("http://127.0.0.1:([0-9]+)/")
+                        ret = pattern.match(u)
+                        self.assertIsNotNone(ret)
+                        return int(ret.group(1))
+                    
+                    self.assertGreaterEqual(_extract_port(resp.url), v.port)
         finally:
             shutil.rmtree(tmp_dir)
 

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -3,7 +3,6 @@
 
 
 import shutil
-from tabnanny import check
 from .cmdline_tmpl import CmdlineTmpl
 import json
 import multiprocessing
@@ -50,7 +49,7 @@ class Viewer(unittest.TestCase):
 
         if use_external_processor:
             self.cmd.append("--use_external_processor")
-        
+
         if port:
             self.port = port
             self.cmd.append("--port")
@@ -109,7 +108,7 @@ class Viewer(unittest.TestCase):
                 return
             time.sleep(1)
         self.fail(f"Can't connect to 127.0.0.1:{port}")
-    
+
     def url(self) -> str:
         return f'http://127.0.0.1:{self.port}'
 
@@ -138,16 +137,12 @@ class MockOpen(unittest.TestCase):
 
 
 class TestViewer(CmdlineTmpl):
-    # def _is_port_free(self, port):
-        # with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
-            # return sock.connect_ex(('localhost', port)) != 0
-        
     def _find_a_free_port(self) -> int:
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         sock.bind(('', 0))
         port = sock.getsockname()[1]
         sock.close()
-        
+
         return port
 
     @unittest.skipIf(sys.platform == "win32", "Can't send Ctrl+C reliably on Windows")

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -427,7 +427,7 @@ class TestViewer(CmdlineTmpl):
                         ret = pattern.match(u)
                         self.assertIsNotNone(ret)
                         return int(ret.group(1))
-                    
+
                     self.assertGreaterEqual(_extract_port(resp.url), v.port)
         finally:
             shutil.rmtree(tmp_dir)

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -144,7 +144,7 @@ class TestViewer(CmdlineTmpl):
         sock.close()
 
         return port
-    
+
     @unittest.skipIf(sys.platform == "win32", "Can't send Ctrl+C reliably on Windows")
     def test_custom_port(self):
         json_script = '{"file_info": {}, "traceEvents": []}'
@@ -165,7 +165,6 @@ class TestViewer(CmdlineTmpl):
                 v.stop()
         finally:
             os.remove(f.name)
-            
 
     @unittest.skipIf(sys.platform == "win32", "Can't send Ctrl+C reliably on Windows")
     def test_json(self):


### PR DESCRIPTION
This is a pull request to solve issue #269.
Summary:
- Add _find_a_free_port into TestViewer
- Add URL method to Viewer
- Change cases use 9001 port to a free dynamic port found before creating a viewer.