### PR TITLE
FIX: Prevent generating `cmdline_test.py` in vcompressor benchmark

### DIFF
--- a/tests/test_vcompressor.py
+++ b/tests/test_vcompressor.py
@@ -132,7 +132,7 @@ class TestVCompressorPerformance(CmdlineTmpl):
     def _benchmark_vcompressor(self, uncompressed_file_path: str, compressed_file_path: str) -> None:
         self.template(
             ["viztracer", "-o", compressed_file_path, "--compress", uncompressed_file_path],
-            expected_output_file=compressed_file_path, cleanup=False
+            expected_output_file=compressed_file_path, script=None, cleanup=False
         )
 
     @_benchmark


### PR DESCRIPTION
I've forgotten cleanup code in #268 so that after benchmark is conducted, there is a `cmdline_test.py` left. Sorry for that :D
This commit should fix it.