### PR TITLE
Compress fee timestamp

### DIFF
--- a/src/viztracer/modules/vcompressor/vc_dump.c
+++ b/src/viztracer/modules/vcompressor/vc_dump.c
@@ -639,11 +639,11 @@ load_events_from_file(FILE* fptr)
                     if (i == 0) {
                         READ_DATA(&ts, int64_t, fptr);
                     } else {
-                        if (read_encoded_int(&ts, fptr)!=0) {
+                        if (read_encoded_int(&ts, fptr) != 0) {
                             goto clean_exit;
                         }
                     }
-                    if (read_encoded_int(&dur, fptr)!=0) {
+                    if (read_encoded_int(&dur, fptr) != 0) {
                         goto clean_exit;
                     }
                     event = PyDict_New();

--- a/src/viztracer/modules/vcompressor/vc_dump.c
+++ b/src/viztracer/modules/vcompressor/vc_dump.c
@@ -761,6 +761,7 @@ load_file_info(FILE* fptr)
     unsigned char* compression_buffer = NULL;
     uint64_t compression_length = 0;
     uint64_t content_length = 0;
+    size_t read_length = 0;
     PyObject* file_info = NULL;
     PyObject* zlib_ret = NULL;
     PyObject* bytes_data = NULL;
@@ -788,7 +789,11 @@ load_file_info(FILE* fptr)
         PyErr_Format(PyExc_RuntimeError, "Failed to malloc memory size %lld", compression_length);
         goto clean_exit;
     }
-    fread(compression_buffer, sizeof(char), compression_length, fptr);
+    read_length = fread(compression_buffer, sizeof(char), compression_length, fptr);
+    if (read_length != compression_length) {
+        PyErr_SetString(PyExc_ValueError, "file is corrupted");
+        goto clean_exit;
+    }         
     bytes_data = PyBytes_FromStringAndSize((const char *)compression_buffer, compression_length);
     free(compression_buffer);
     if (!bytes_data) {

--- a/src/viztracer/modules/vcompressor/vc_dump.c
+++ b/src/viztracer/modules/vcompressor/vc_dump.c
@@ -84,26 +84,26 @@ static inline void write_encoded_int(uint64_t num, FILE* fptr)
 static inline int read_encoded_int(uint64_t *num, FILE* fptr)
 {
     uint8_t flag;
+    uint8_t encoded_num_8_bit = 0;
+    uint16_t encoded_num_16_bit = 0;
+    uint32_t encoded_num_32_bit = 0;
+    uint64_t encoded_num_64_bit = 0;
     PEEK_DATA(&flag, uint8_t, fptr)
     switch (flag & 0x03)
     {
         case TS_6_BIT:
-            uint8_t encoded_num_8_bit = 0;
             READ_DATA(&encoded_num_8_bit, uint8_t, fptr)
             (*num) = encoded_num_8_bit >> 2;
             break;
         case TS_14_BIT:
-            uint16_t encoded_num_16_bit = 0;
             READ_DATA(&encoded_num_16_bit, uint16_t, fptr)
             (*num) = encoded_num_16_bit >> 2;
             break;        
         case TS_30_BIT:
-            uint32_t encoded_num_32_bit = 0;
             READ_DATA(&encoded_num_32_bit, uint32_t, fptr)
             (*num) = encoded_num_32_bit >> 2;
             break;
         case TS_62_BIT:
-            uint64_t encoded_num_64_bit = 0;
             READ_DATA(&encoded_num_64_bit, uint64_t, fptr)
             (*num) = encoded_num_64_bit >> 2;
             break;

--- a/src/viztracer/modules/vcompressor/vc_dump.c
+++ b/src/viztracer/modules/vcompressor/vc_dump.c
@@ -55,7 +55,7 @@
     case TS_32_BIT:                                                          \
         uint32_t encoded_int_32;                                             \
         READ_DATA(&encoded_int_32, uint32_t, fptr);                          \
-        num = encoded_int_32;;                                               \
+        num = encoded_int_32;                                                \
         break;                                                               \
     case TS_64_BIT:                                                          \
         uint64_t encoded_int_64;                                             \

--- a/src/viztracer/modules/vcompressor/vc_dump.c
+++ b/src/viztracer/modules/vcompressor/vc_dump.c
@@ -1,4 +1,4 @@
-// Licensed under the Apache License: http://www.apache.org/licenses/LICENSE-_2.0
+// Licensed under the Apache License: http://www.apache.org/licenses/LICENSE-2.0
 // For details: https://github.com/gaogaotiantian/viztracer/blob/master/NOTICE.txt
 
 #include <Python.h>

--- a/src/viztracer/modules/vcompressor/vc_dump.c
+++ b/src/viztracer/modules/vcompressor/vc_dump.c
@@ -41,6 +41,9 @@
 #define READ_ENCODED_INT64(num, fptr)                                        \
 {                                                                            \
     uint8_t flag = 0;                                                        \
+    uint8_t encoded_int_low = 0;                                             \
+    uint32_t encoded_int_32 = 0;                                             \
+    uint64_t encoded_int_64 = 0;                                             \
     READ_DATA(&flag, uint8_t, fptr);                                         \
     switch (flag & 0xC0)                                                     \
     {                                                                        \
@@ -48,17 +51,14 @@
             num = flag & 0x3F;                                               \
             break;                                                           \
         case TS_14_BIT:                                                      \
-            uint8_t encoded_int_low;                                         \
             READ_DATA(&encoded_int_low, uint8_t, fptr);                      \
             num = ((flag & 0x3F) << 8) | encoded_int_low;                    \
             break;                                                           \
         case TS_32_BIT:                                                      \
-            uint32_t encoded_int_32;                                         \
             READ_DATA(&encoded_int_32, uint32_t, fptr);                      \
             num = encoded_int_32;                                            \
             break;                                                           \
         case TS_64_BIT:                                                      \
-            uint64_t encoded_int_64;                                         \
             READ_DATA(&encoded_int_64, uint64_t, fptr);                      \
             num = encoded_int_64;                                            \
             break;                                                           \

--- a/src/viztracer/modules/vcompressor/vc_dump.c
+++ b/src/viztracer/modules/vcompressor/vc_dump.c
@@ -44,27 +44,27 @@
     READ_DATA(&flag, uint8_t, fptr);                                         \
     switch (flag & 0xC0)                                                     \
     {                                                                        \
-    case TS_6_BIT:                                                           \
-        num = flag & 0x3F;                                                   \
-        break;                                                               \
-    case TS_14_BIT:                                                          \
-        uint8_t encoded_int_low;                                             \
-        READ_DATA(&encoded_int_low, uint8_t, fptr);                          \
-        num = ((flag & 0x3F) << 8) | encoded_int_low;                        \
-        break;                                                               \
-    case TS_32_BIT:                                                          \
-        uint32_t encoded_int_32;                                             \
-        READ_DATA(&encoded_int_32, uint32_t, fptr);                          \
-        num = encoded_int_32;                                                \
-        break;                                                               \
-    case TS_64_BIT:                                                          \
-        uint64_t encoded_int_64;                                             \
-        READ_DATA(&encoded_int_64, uint64_t, fptr);                          \
-        num = encoded_int_64;                                                \
-        break;                                                               \
-    default:                                                                 \
-        printf("shouldn't be here!!!");                                      \
-        break;                                                               \
+        case TS_6_BIT:                                                       \
+            num = flag & 0x3F;                                               \
+            break;                                                           \
+        case TS_14_BIT:                                                      \
+            uint8_t encoded_int_low;                                         \
+            READ_DATA(&encoded_int_low, uint8_t, fptr);                      \
+            num = ((flag & 0x3F) << 8) | encoded_int_low;                    \
+            break;                                                           \
+        case TS_32_BIT:                                                      \
+            uint32_t encoded_int_32;                                         \
+            READ_DATA(&encoded_int_32, uint32_t, fptr);                      \
+            num = encoded_int_32;                                            \
+            break;                                                           \
+        case TS_64_BIT:                                                      \
+            uint64_t encoded_int_64;                                         \
+            READ_DATA(&encoded_int_64, uint64_t, fptr);                      \
+            num = encoded_int_64;                                            \
+            break;                                                           \
+        default:                                                             \
+            printf("shouldn't be here!!!");                                  \
+            break;                                                           \
     }                                                                        \
 }                                                                            \
 

--- a/src/viztracer/modules/vcompressor/vc_dump.c
+++ b/src/viztracer/modules/vcompressor/vc_dump.c
@@ -38,6 +38,57 @@
     fputc('\0', fptr);                                                       \
 }
 
+#define READ_ENCODED_INT64(num, fptr)                                        \
+{                                                                            \
+    uint8_t flag = 0;                                                        \
+    READ_DATA(&flag, uint8_t, fptr);                                         \
+    switch (flag & 0xC0)                                                     \
+    {                                                                        \
+    case TS_6_BIT:                                                           \
+        num = flag & 0x3F;                                                   \
+        break;                                                               \
+    case TS_14_BIT:                                                          \
+        uint8_t encoded_int_low;                                             \
+        READ_DATA(&encoded_int_low, uint8_t, fptr);                          \
+        num = ((flag & 0x3F) << 8) | encoded_int_low;                        \
+        break;                                                               \
+    case TS_32_BIT:                                                          \
+        uint32_t encoded_int_32;                                             \
+        READ_DATA(&encoded_int_32, uint32_t, fptr);                          \
+        num = encoded_int_32;;                                               \
+        break;                                                               \
+    case TS_64_BIT:                                                          \
+        uint64_t encoded_int_64;                                             \
+        READ_DATA(&encoded_int_64, uint64_t, fptr);                          \
+        num = encoded_int_64;                                                \
+        break;                                                               \
+    default:                                                                 \
+        printf("shouldn't be here!!!");                                      \
+        break;                                                               \
+    }                                                                        \
+}                                                                            \
+
+#define WRITE_ENDOCED_INT64(dump_int, fptr)                                  \
+{                                                                            \
+    if((dump_int & 0x3F) == dump_int){                                       \
+        uint8_t encoded_ts = TS_6_BIT | dump_int;                            \
+        fputc(encoded_ts, fptr);                                             \
+    } else if ((dump_int & 0x3FFF) == dump_int)                              \
+    {                                                                        \
+        uint8_t encoded_ts_high = TS_14_BIT | (dump_int >> 8);               \
+        uint8_t encoded_ts_low = 0xFF & dump_int;                            \
+        fputc(encoded_ts_high, fptr);                                        \
+        fputc(encoded_ts_low, fptr);                                         \
+    } else if ((dump_int & 0xFFFFFFFF) == dump_int){                         \
+        uint32_t encoded_ts = dump_int;                                      \
+        fputc(TS_32_BIT, fptr);                                              \
+        fwrite(&encoded_ts, sizeof(uint32_t), 1, fptr);                      \
+    } else {                                                                 \
+        fputc(TS_64_BIT, fptr);                                              \
+        fwrite(&dump_int, sizeof(uint64_t), 1, fptr);                        \
+    }                                                                        \
+}                                                                            \
+
 int freadstrn(char* buffer, int n, FILE* fptr) 
 {
     int c;
@@ -93,62 +144,6 @@ int dump_metadata(FILE* fptr)
     return 0;
 }
 
-void dump_encoded_int(uint64_t delta_ts, FILE* fptr){
-    if((delta_ts & 0x3F) == delta_ts){
-        unsigned char encoded_ts = TS_6_BIT | delta_ts;
-        fputc(encoded_ts, fptr);
-        cnt_6_bit_cnt += 1;
-    } else if ((delta_ts & 0x3FFF) == delta_ts)
-    {
-        unsigned char encoded_ts_high = TS_14_BIT | (delta_ts >> 8);
-        unsigned char encoded_ts_low = 0xFF & delta_ts;
-        fputc(encoded_ts_high, fptr);
-        fputc(encoded_ts_low, fptr);
-        cnt_14_bit_cnt += 1;
-    } else if ((delta_ts & 0xFFFFFFFF) == delta_ts){
-        uint32_t encoded_ts = delta_ts;
-        fputc(TS_32_BIT, fptr);
-        fwrite(&encoded_ts, sizeof(uint32_t), 1, fptr);
-        cnt_32_bit_cnt += 1;
-    } else {
-        fputc(TS_64_BIT, fptr);
-        fwrite(&delta_ts, sizeof(uint64_t), 1, fptr);
-        cnt_64_bit_cnt += 1;
-    }
-}
-
-int32_t load_encoded_int(uint64_t * out_encoded_int, FILE* fptr){
-    uint8_t flag = 0;
-    READ_DATA(&flag, uint8_t, fptr);
-    switch (flag & 0xC0)
-    {
-    case TS_6_BIT:
-        (*out_encoded_int) = flag & 0x3F;
-        break;
-    case TS_14_BIT:
-        uint8_t encoded_int_low;
-        READ_DATA(&encoded_int_low, uint8_t, fptr);
-        (*out_encoded_int) = ((flag & 0x3F) << 8) | encoded_int_low;
-        break;
-    case TS_32_BIT:
-        uint32_t encoded_int_32;
-        READ_DATA(&encoded_int_32, uint32_t, fptr);
-        (*out_encoded_int) = encoded_int_32;;
-        break;
-    case TS_64_BIT:
-        uint64_t encoded_int_64;
-        READ_DATA(&encoded_int_64, uint64_t, fptr);
-        (*out_encoded_int) = encoded_int_64;
-        break;
-    default:
-        printf("shouldn't be here!!!");
-        break;
-    }
-    return 0;
-clean_exit:
-    return 1;
-}
-
 int dump_parsed_trace_events(PyObject* trace_events, FILE* fptr)
 {
     // Dump process and thread names
@@ -191,8 +186,8 @@ int dump_parsed_trace_events(PyObject* trace_events, FILE* fptr)
         uint64_t tid = PyLong_AsLong(PyTuple_GetItem(key, 1));
         const char* name = PyUnicode_AsUTF8(PyTuple_GetItem(key, 2));
         uint64_t ts_size = PyDict_Size(value);
+        uint64_t ts_cache = 0;
         PyObject* ts_keys = PyDict_Keys(value);
-        double ts_cache = 0;
         fputc(VC_HEADER_FEE, fptr);
         fwrite(&pid, sizeof(uint64_t), 1, fptr);
         fwrite(&tid, sizeof(uint64_t), 1, fptr);
@@ -205,17 +200,16 @@ int dump_parsed_trace_events(PyObject* trace_events, FILE* fptr)
         if (PyList_Sort(ts_keys) == -1) {
             goto clean_exit;
         }
-        printf("%ld\n", ts_size);
         for (Py_ssize_t idx = 0; idx < (Py_ssize_t)ts_size; idx++) {
             PyObject * ts_obj = PyList_GET_ITEM(ts_keys, idx);
             double ts = PyFloat_AsDouble(ts_obj);
             double dur = PyFloat_AsDouble(PyDict_GetItem(value, ts_obj));
-            double delta_ts = ts - ts_cache;
-            ts_cache = ts;
-            uint64_t ts64 = delta_ts * 1000;
-            uint64_t dur64 = dur * 1000;
-            dump_encoded_int(ts64, fptr);
-            dump_encoded_int(dur64, fptr);
+            uint64_t ts64 = ts * 100;
+            uint64_t dur64 = dur * 100;
+            uint64_t delta_ts = ts64 - ts_cache;
+            ts_cache = ts64;
+            WRITE_ENDOCED_INT64(delta_ts, fptr);
+            WRITE_ENDOCED_INT64(dur64, fptr);
         }
     }
 
@@ -551,6 +545,7 @@ load_events_from_file(FILE* fptr)
     uint64_t count = 0;
     uint64_t ts = 0;
     uint64_t dur = 0;
+    uint64_t ts_cache = 0;
     PyObject* args = NULL;
     PyObject* unicode_X = PyUnicode_FromString("X");
     PyObject* unicode_M = PyUnicode_FromString("M");
@@ -611,17 +606,19 @@ load_events_from_file(FILE* fptr)
                 freadstrn(buffer, STRING_BUFFER_SIZE - 1, fptr);
                 READ_DATA(&count, uint64_t, fptr);
                 name = PyUnicode_FromString(buffer);
-                for (uint64_t i = 0; i < count / 2; i++) {
-                    READ_DATA(&ts, uint64_t, fptr);
-                    READ_DATA(&dur, uint64_t, fptr);
+                ts_cache = 0;
+                for (uint64_t i = 0; i < count; i++) {
+                    READ_ENCODED_INT64(ts, fptr);
+                    READ_ENCODED_INT64(dur, fptr);
                     event = PyDict_New();
                     PyDict_SetItemString(event, "ph", unicode_X);
                     PyDict_SetItemString(event, "name", name);
                     PyDict_SetItemString(event, "cat", unicode_FEE);
                     PyDict_SetItemStringULL(event, "pid", pid);
                     PyDict_SetItemStringULL(event, "tid", tid);
-                    PyDict_SetItemStringDouble(event, "ts", (double)ts / 1000);
-                    PyDict_SetItemStringDouble(event, "dur", (double)dur / 1000);
+                    ts_cache = ts + ts_cache;
+                    PyDict_SetItemStringDouble(event, "ts", (double)ts_cache / 100);
+                    PyDict_SetItemStringDouble(event, "dur", (double)dur / 100);
                     PyList_Append(trace_events, event);
                     Py_DECREF(event);
                 }

--- a/src/viztracer/modules/vcompressor/vc_dump.h
+++ b/src/viztracer/modules/vcompressor/vc_dump.h
@@ -15,6 +15,13 @@
 #define VC_HEADER_COUNTER_ARG_FLOAT 0x24
 #define VC_HEADER_COUNTER_ARG_LONG_STRING 0x25
 
+#define TS_6_BIT   0x00
+#define TS_14_BIT  0x40
+#define TS_32_BIT  0x80
+#define TS_64_BIT  0xC0
+
+void dump_delta_timestamp(uint64_t delta_ts, FILE* fptr);
+
 int dump_metadata(FILE* fptr);
 
 int dump_parsed_trace_events(PyObject* trace_events, FILE* fptr);

--- a/src/viztracer/modules/vcompressor/vc_dump.h
+++ b/src/viztracer/modules/vcompressor/vc_dump.h
@@ -20,8 +20,6 @@
 #define TS_32_BIT  0x80
 #define TS_64_BIT  0xC0
 
-void dump_delta_timestamp(uint64_t delta_ts, FILE* fptr);
-
 int dump_metadata(FILE* fptr);
 
 int dump_parsed_trace_events(PyObject* trace_events, FILE* fptr);

--- a/src/viztracer/modules/vcompressor/vc_dump.h
+++ b/src/viztracer/modules/vcompressor/vc_dump.h
@@ -16,9 +16,9 @@
 #define VC_HEADER_COUNTER_ARG_LONG_STRING 0x25
 
 #define TS_6_BIT   0x00
-#define TS_14_BIT  0x40
-#define TS_32_BIT  0x80
-#define TS_64_BIT  0xC0
+#define TS_14_BIT  0x01
+#define TS_30_BIT  0x02
+#define TS_62_BIT  0x03
 
 int dump_metadata(FILE* fptr);
 

--- a/src/viztracer/modules/vcompressor/vcompressor.c
+++ b/src/viztracer/modules/vcompressor/vcompressor.c
@@ -60,7 +60,8 @@ parse_trace_events(PyObject* trace_events)
         PyObject* ts = NULL;
         PyObject* dur = NULL;
         PyObject* counter_args = NULL;
-        PyObject* event_ts_dict = NULL;
+        PyObject* ts_dur_tuple = NULL;
+        PyObject* event_ts_list = NULL;
         PyObject* counter_event_dict = NULL;
         if (PyErr_Occurred() || !PyDict_CheckExact(event)) {
             PyErr_SetString(PyExc_ValueError, "event format failure");
@@ -94,14 +95,21 @@ parse_trace_events(PyObject* trace_events)
                 PyTuple_SetItem(key, 2, name);
 
                 if (!PyDict_Contains(fee_events, key)) {
-                    event_ts_dict = PyDict_New();
-                    PyDict_SetItem(fee_events, key, event_ts_dict);
-                    Py_DECREF(event_ts_dict);
+                    event_ts_list = PyList_New(0);
+                    PyDict_SetItem(fee_events, key, event_ts_list);
+                    Py_DECREF(event_ts_list);
                 } else {
-                    event_ts_dict = PyDict_GetItem(fee_events, key);
+                    event_ts_list = PyDict_GetItem(fee_events, key);
                 }
                 Py_DECREF(key);
-                PyDict_SetItem(event_ts_dict, ts, dur);
+                
+                ts_dur_tuple = PyTuple_New(2);
+                Py_INCREF(ts);
+                Py_INCREF(dur);
+                PyTuple_SetItem(ts_dur_tuple, 0, ts);
+                PyTuple_SetItem(ts_dur_tuple, 1, dur);
+                PyList_Append(event_ts_list, ts_dur_tuple);
+                Py_DECREF(ts_dur_tuple);
                 break;
             case 'M':
                 name = PyDict_GetItemString(event, "name");

--- a/src/viztracer/modules/vcompressor/vcompressor.c
+++ b/src/viztracer/modules/vcompressor/vcompressor.c
@@ -60,7 +60,7 @@ parse_trace_events(PyObject* trace_events)
         PyObject* ts = NULL;
         PyObject* dur = NULL;
         PyObject* counter_args = NULL;
-        PyObject* event_ts_list = NULL;
+        PyObject* event_ts_dict = NULL;
         PyObject* counter_event_dict = NULL;
         if (PyErr_Occurred() || !PyDict_CheckExact(event)) {
             PyErr_SetString(PyExc_ValueError, "event format failure");
@@ -94,15 +94,14 @@ parse_trace_events(PyObject* trace_events)
                 PyTuple_SetItem(key, 2, name);
 
                 if (!PyDict_Contains(fee_events, key)) {
-                    event_ts_list = PyList_New(0);
-                    PyDict_SetItem(fee_events, key, event_ts_list);
-                    Py_DECREF(event_ts_list);
+                    event_ts_dict = PyDict_New();
+                    PyDict_SetItem(fee_events, key, event_ts_dict);
+                    Py_DECREF(event_ts_dict);
                 } else {
-                    event_ts_list = PyDict_GetItem(fee_events, key);
+                    event_ts_dict = PyDict_GetItem(fee_events, key);
                 }
                 Py_DECREF(key);
-                PyList_Append(event_ts_list, ts);
-                PyList_Append(event_ts_list, dur);
+                PyDict_SetItem(event_ts_dict, ts, dur);
                 break;
             case 'M':
                 name = PyDict_GetItemString(event, "name");

--- a/tests/test_vcompressor.py
+++ b/tests/test_vcompressor.py
@@ -100,7 +100,7 @@ def fib(n):
     if n < 2:
         return 1
     return fib(n-1) + fib(n-2)
-fib(28)
+fib(27)
 
 tracer.stop()
 tracer.save(output_file='%s')

--- a/tests/test_vcompressor.py
+++ b/tests/test_vcompressor.py
@@ -404,7 +404,6 @@ class TestVCompressorCorrectness(CmdlineTmpl, VCompressorCompare):
                 dup_json_data = json.load(f)
         return origin_json_data, dup_json_data
 
-
     def test_file_info(self):
         origin_json_data, dup_json_data = self._generate_test_data("multithread.json")
         self.assertEqual(origin_json_data["file_info"], dup_json_data["file_info"])
@@ -420,7 +419,7 @@ class TestVCompressorCorrectness(CmdlineTmpl, VCompressorCompare):
                 if event_key not in origin_fee_events:
                     origin_fee_events[event_key] = []
                 origin_fee_events[event_key].append(event)
-        
+
         dup_fee_events = {}
         for event in dup_json_data["traceEvents"]:
             if event["ph"] == "X":

--- a/tests/test_vcompressor.py
+++ b/tests/test_vcompressor.py
@@ -262,6 +262,7 @@ class TestVCompressorPerformance(CmdlineTmpl):
                 self._print_result(filename, original_size,
                                    vcompress_result, other_results, subtest_idx=subtest_idx)
 
+    @unittest.skipUnless(os.getenv("GITHUB_ACTIONS"), "skipped because not in github actions")
     def test_benchmark_large_file(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             origin_json_path = os.path.join(tmpdir, "large_fib.json")
@@ -368,7 +369,8 @@ def call_self(n):
     if n == 0:
         return
     return call_self(n-1)
-call_self(10)
+for _ in range(10):
+    call_self(1000)
 
 tracer.stop()
 tracer.save(output_file='%s')


### PR DESCRIPTION
Source code that generate trace file is:
```
from viztracer import VizTracer
tracer = VizTracer(tracer_entries=2000000)
tracer.start()

def fib(n):
    if n < 2:
        return 1
    return fib(n-1) + fib(n-2)
fib(28)

tracer.stop()
tracer.save()
```
The compress result is here:
```
2023-02-18 00:28:07,843 INFO: On file "large_fib.json":
2023-02-18 00:28:07,843 INFO:     [Space]
2023-02-18 00:28:07,843 INFO:       Uncompressed:     146.95MB
2023-02-18 00:28:07,843 INFO:       VCompressor:        2.30MB(1.000) [CR:  1.57%]
2023-02-18 00:28:07,843 INFO:       LZMA:               5.40MB(2.345) [CR:  3.67%]
2023-02-18 00:28:07,843 INFO:       ZLIB:               7.00MB(3.041) [CR:  4.76%]
2023-02-18 00:28:07,843 INFO:       VC+LZMA:          751.95KB(0.319) [CR:  0.50%]
2023-02-18 00:28:07,843 INFO:       VC+ZLIB:            0.98MB(0.428) [CR:  0.67%]
2023-02-18 00:28:07,843 INFO:     [Time]
2023-02-18 00:28:07,843 INFO:       VCompressor:        2.461s(1.000)
2023-02-18 00:28:07,843 INFO:       LZMA:               8.242s(3.350)
2023-02-18 00:28:07,843 INFO:       ZLIB:               0.914s(0.372)
2023-02-18 00:28:07,843 INFO:       VC+LZMA:            8.248s(3.352)
2023-02-18 00:28:07,843 INFO:       VC+ZLIB:            7.166s(2.912)
```
And I've also tested it with game trace file, here's results:
```
2023-02-18 00:49:08,214 INFO: On file "result_game.json":
2023-02-18 00:49:08,214 INFO:     [Space]
2023-02-18 00:49:08,214 INFO:       Uncompressed:     117.28MB
2023-02-18 00:49:08,214 INFO:       VCompressor:        3.13MB(1.000) [CR:  2.67%]
2023-02-18 00:49:08,214 INFO:       LZMA:               4.13MB(1.322) [CR:  3.53%]
2023-02-18 00:49:08,214 INFO:       ZLIB:               6.11MB(1.955) [CR:  5.21%]
2023-02-18 00:49:08,215 INFO:       VC+LZMA:            1.51MB(0.484) [CR:  1.29%]
2023-02-18 00:49:08,215 INFO:       VC+ZLIB:            1.72MB(0.549) [CR:  1.46%]
2023-02-18 00:49:08,215 INFO:     [Time]
2023-02-18 00:49:08,215 INFO:       VCompressor:        2.168s(1.000)
2023-02-18 00:49:08,215 INFO:       LZMA:               7.399s(3.412)
2023-02-18 00:49:08,215 INFO:       ZLIB:               0.862s(0.398)
2023-02-18 00:49:08,215 INFO:       VC+LZMA:           12.963s(5.978)
2023-02-18 00:49:08,215 INFO:       VC+ZLIB:            2.586s(1.193)
``` 
For large file, the optimization is obvious.

There may be more methods to make compress rate lower. For example, function name can be compressed because most files are in the same directory, and maybe timestamp can be further compressed.