### PR TITLE
Fix 318

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,6 +9,6 @@ mypy
 coverage
 
 # 3rd party packages for test
-ipywidgets
+ipywidgets==8.0.4
 loky>=3.0.0
 jaxlib; sys_platform != 'win32' and python_version < '3.11'

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,6 +9,8 @@ mypy
 coverage
 
 # 3rd party packages for test
+ipykernel
+pytest
 ipywidgets==8.0.4
 loky>=3.0.0
 jaxlib; sys_platform != 'win32' and python_version < '3.11'


### PR DESCRIPTION
There's several things about this issue #318 
1. The test fail: I think the test fail is because some bugs of ipywidgets, https://github.com/jupyter-widgets/ipywidgets/issues/3739 and https://github.com/jupyter-widgets/pythreejs/issues/399 are related bugs. So to fix the test fail, for now we can use `ipywidgets==8.0.4`
2.  The skipped test: I found that this fail was only occurred in python 3.7 because of IPython. IPython 8+ supports Python 3.8 and above, and Python 3.7 was supported with 7.x. for Python 3.8 and above, `from IPython.testing.globalipapp import start_ipython` will import `pytest` as dependency, which is not installed and triggered `ImportError`. One solution is to add `pytest` to `requirements-dev.txt`. Another solution is to use this samplecode to test:
  ```python
  from traitlets.config.loader import Config
  import tempfile
  from pathlib import Path
  
  def default_config():
      config = Config()
      config.TerminalInteractiveShell.colors = 'NoColor'
      config.TerminalTerminalInteractiveShell.term_title = False,
      config.TerminalInteractiveShell.autocall = 0
      f = tempfile.NamedTemporaryFile(suffix=u'test_hist.sqlite', delete=False)
      config.HistoryManager.hist_file = Path(f.name)
      f.close()
      config.HistoryManager.db_cache_size = 10000
      return config
  
  def get_ipython():
      from IPython.terminal.interactiveshell import TerminalInteractiveShell
      if TerminalInteractiveShell._instance:
          return TerminalInteractiveShell.instance()
      config = default_config()
      config.TerminalInteractiveShell.simple_prompt = True
      shell = TerminalInteractiveShell.instance(config=config)
      return shell
  
  ip = get_ipython()
  ip.magic("load_ext viztracer")
  ip.run_cell_magic(magic_name="viztracer", line="", cell="print(1)")
  ```
3. I added `ipykernel` because of this issue https://github.com/jupyter-widgets/ipywidgets/issues/3731. For now maybe we don't need this. But if we need to use a newer version of ipywidgets, this is necessary.