### PR TITLE
Better popen patching

### DIFF
--- a/src/viztracer/patch.py
+++ b/src/viztracer/patch.py
@@ -73,6 +73,7 @@ def patch_subprocess(viz_args: list[str]) -> None:
 
         if new_args is None:
             new_args = args
+        assert hasattr(subprocess_init, "__wrapped__")  # for mypy
         subprocess_init.__wrapped__(self, new_args, **kwargs)
 
     # We need to filter the arguments as there are something we may not want

--- a/tests/test_patch.py
+++ b/tests/test_patch.py
@@ -125,10 +125,10 @@ class TestPatchSpawn(CmdlineTmpl):
         a = self.template(["python", "cmdline_test.py"],
                           expected_output_file=None,
                           script=check_output)
-        b = self.template(["viztracer", "cmdline_test.py"],
+        b = self.template(["viztracer", "--quiet", "cmdline_test.py"],
                           expected_output_file="result.json",
                           script=check_output)
-        self.assertEqual(a.stdout, b.stdout[:len(a.stdout)])
+        self.assertEqual(a.stdout, b.stdout)
 
 
 class TestPatchSideEffect(CmdlineTmpl):

--- a/tests/test_patch.py
+++ b/tests/test_patch.py
@@ -63,6 +63,28 @@ def foo():
 """
 
 
+check_output = r"""
+import os
+import subprocess
+
+with open("check_output_echo.py", "w") as f:
+    f.write("import sys; print(sys.argv)")
+
+print(subprocess.check_output(["python", "--version"], text=True).strip())
+print(subprocess.check_output(["python", "-cprint(5)"]))
+print(subprocess.check_output(["python", "check_output_echo.py"], text=True))
+print(subprocess.check_output(["python", "-v", "--", "check_output_echo.py", "-a", "42"]))
+print(subprocess.check_output(["python", "-Es", "check_output_echo.py", "-v", "--my_arg=foo bar"], text=True))
+print(subprocess.check_output(["python", "-Esm", "check_output_echo", "-abc"]))
+print(subprocess.check_output(["python", "-c", r"import sys; sys.stdout.buffer.write(b'\0\1\2\3\4')"]))
+print(subprocess.check_output(["python", "-", "foo"], input=b"import sys; print(sys.argv)"))
+print(subprocess.check_output(["python"], input=b"import sys; print(sys.argv)"))
+print(subprocess.check_output(["python", "-im", "check_output_echo", "asdf"], input=b"import sys; print(sys.argv)"))
+
+os.remove("check_output_echo.py")
+"""
+
+
 file_after_patch_check = """
 import multiprocessing.spawn
 import subprocess
@@ -98,6 +120,15 @@ class TestPatchSpawn(CmdlineTmpl):
         self.assertEqual(len(files), 1)
         self.assertTrue(re.match(r"result_[0-9]*\.json", files[0]))
         shutil.rmtree(tmpdir)
+
+    def test_patch_args(self):
+        a = self.template(["python", "cmdline_test.py"],
+                          expected_output_file=None,
+                          script=check_output)
+        b = self.template(["viztracer", "cmdline_test.py"],
+                          expected_output_file="result.json",
+                          script=check_output)
+        self.assertEqual(a.stdout, b.stdout[:len(a.stdout)])
 
 
 class TestPatchSideEffect(CmdlineTmpl):


### PR DESCRIPTION
`viz_args` needs to be copied before modifying it to avoid accumulating args across invocations. Can also handle combined options e.g. `-Es` now.