### PR TITLE
some code cleanups and python 3 adjustments

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,4 +1,11 @@
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+import os
+
 import sphinx_rtd_theme  # noqa: F401
+
 # Configuration file for the Sphinx documentation builder.
 #
 # This file only contains a selection of the most common options. For a full
@@ -7,11 +14,6 @@ import sphinx_rtd_theme  # noqa: F401
 
 # -- Path setup --------------------------------------------------------------
 
-# If extensions (or modules to document with autodoc) are in another directory,
-# add these directories to sys.path here. If the directory is relative to the
-# documentation root, use os.path.abspath to make it absolute, like shown here.
-#
-import os
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -42,7 +42,7 @@ with open(init_path) as f:
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    "sphinx_rtd_theme"
+    "sphinx_rtd_theme",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,11 +1,4 @@
-# If extensions (or modules to document with autodoc) are in another directory,
-# add these directories to sys.path here. If the directory is relative to the
-# documentation root, use os.path.abspath to make it absolute, like shown here.
-#
-import os
-
 import sphinx_rtd_theme  # noqa: F401
-
 # Configuration file for the Sphinx documentation builder.
 #
 # This file only contains a selection of the most common options. For a full
@@ -14,6 +7,11 @@ import sphinx_rtd_theme  # noqa: F401
 
 # -- Path setup --------------------------------------------------------------
 
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+import os
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
 
@@ -42,7 +40,7 @@ with open(init_path) as f:
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    "sphinx_rtd_theme",
+    "sphinx_rtd_theme"
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/example/generate_examples.py
+++ b/example/generate_examples.py
@@ -18,7 +18,7 @@ if __name__ == "__main__":
         "mcts_game": ["--log_gc"],
         "logging_integration": ["--include_files", os.path.dirname(__file__)],
         "multi_process_pool": ["--log_multiprocess"],
-        "async_simple": ["--log_async"]
+        "async_simple": ["--log_async"],
     }
     for script in os.listdir(os.path.join(os.path.dirname(__file__), "src")):
         if script.split(".")[0] in vt_options:

--- a/example/src/different_sorts.py
+++ b/example/src/different_sorts.py
@@ -1,8 +1,9 @@
 # https://github.com/TheAlgorithms/Python
 
 
-import random
 import os
+import random
+
 from viztracer import VizTracer
 
 

--- a/example/src/function_args_return.py
+++ b/example/src/function_args_return.py
@@ -1,4 +1,5 @@
 import os
+
 from viztracer import VizTracer
 
 

--- a/example/src/gradient_descent.py
+++ b/example/src/gradient_descent.py
@@ -28,7 +28,7 @@ def _error(example_no, data_set="train"):
     :return: error in example pointed by example number.
     """
     return calculate_hypothesis_value(example_no, data_set) - output(
-        example_no, data_set
+        example_no, data_set,
     )
 
 

--- a/example/src/gradient_descent.py
+++ b/example/src/gradient_descent.py
@@ -2,9 +2,10 @@
 
 import math
 import os
-import numpy
-from viztracer import VizTracer, VizCounter
 
+import numpy
+
+from viztracer import VizCounter, VizTracer
 
 # List of input, output pairs
 train_data = (

--- a/example/src/logging_integration.py
+++ b/example/src/logging_integration.py
@@ -5,7 +5,7 @@ from viztracer import VizLoggingHandler, get_tracer
 
 def fib(n):
     if n < 2:
-        logging.warn("Base case, return 1")
+        logging.warning("Base case, return 1")
         return 1
     logging.info(f"Recursive, working on {n}")
     return fib(n - 1) + fib(n - 2)

--- a/example/src/logging_integration.py
+++ b/example/src/logging_integration.py
@@ -7,7 +7,7 @@ def fib(n):
     if n < 2:
         logging.warn("Base case, return 1")
         return 1
-    logging.info("Recursive, working on {}".format(n))
+    logging.info(f"Recursive, working on {n}")
     return fib(n - 1) + fib(n - 2)
 
 

--- a/example/src/logging_integration.py
+++ b/example/src/logging_integration.py
@@ -1,5 +1,6 @@
 import logging
-from viztracer import get_tracer, VizLoggingHandler
+
+from viztracer import VizLoggingHandler, get_tracer
 
 
 def fib(n):

--- a/example/src/mcts_game.py
+++ b/example/src/mcts_game.py
@@ -1,10 +1,11 @@
 
 from __future__ import division
 
-from copy import deepcopy
-from mcts import mcts
-from functools import reduce
 import operator
+from copy import deepcopy
+from functools import reduce
+
+from mcts import mcts
 
 
 class NaughtsAndCrossesState():

--- a/example/src/multi_process_pool.py
+++ b/example/src/multi_process_pool.py
@@ -1,5 +1,5 @@
-from multiprocessing import Pool
 import os
+from multiprocessing import Pool
 
 
 def f(x):

--- a/example/src/multithread.py
+++ b/example/src/multithread.py
@@ -1,6 +1,7 @@
 import os
 import threading
 import time
+
 from viztracer import VizTracer
 
 

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with open("./src/viztracer/__init__.py") as f:
             break
     else:
         print("Can't find version! Stop Here!")
-        exit(1)
+        sys.exit(1)
 
 # Determine which attach binary to take into package
 package_data = {

--- a/setup.py
+++ b/setup.py
@@ -28,23 +28,23 @@ package_data = {
         "web_dist/*/*/*",
         "attach_process/__init__.py",
         "attach_process/add_code_to_python_process.py",
-        "attach_process/LICENSE"
-    ]
+        "attach_process/LICENSE",
+    ],
 }
 
 if sys.platform == "darwin":
     package_data["viztracer"].extend([
         "attach_process/attach_x86_64.dylib",
-        "attach_process/linux_and_mac/lldb_prepare.py"
+        "attach_process/linux_and_mac/lldb_prepare.py",
     ])
 elif sys.platform in ("linux", "linux2"):
     if platform.machine() == "i686":
         package_data["viztracer"].extend([
-            "attach_process/attach_linux_x86.so"
+            "attach_process/attach_linux_x86.so",
         ])
     elif platform.machine() == "x86_64":
         package_data["viztracer"].extend([
-            "attach_process/attach_linux_amd64.so"
+            "attach_process/attach_linux_amd64.so",
         ])
 
 setuptools.setup(
@@ -65,19 +65,19 @@ setuptools.setup(
             sources=[
                 "src/viztracer/modules/util.c",
                 "src/viztracer/modules/eventnode.c",
-                "src/viztracer/modules/snaptrace.c"
+                "src/viztracer/modules/snaptrace.c",
             ],
             extra_compile_args={"win32": []}.get(sys.platform, ["-Werror", "-std=c99"]),
-            extra_link_args={"win32": []}.get(sys.platform, ["-lpthread"])
+            extra_link_args={"win32": []}.get(sys.platform, ["-lpthread"]),
         ),
         setuptools.Extension(
             "viztracer.vcompressor",
             sources=[
                 "src/viztracer/modules/vcompressor/vcompressor.c",
-                "src/viztracer/modules/vcompressor/vc_dump.c"
+                "src/viztracer/modules/vcompressor/vc_dump.c",
             ],
-            extra_compile_args={"win32": []}.get(sys.platform, ["-Werror", "-std=c99"])
-        )
+            extra_compile_args={"win32": []}.get(sys.platform, ["-Werror", "-std=c99"]),
+        ),
     ],
     classifiers=[
         "Development Status :: 4 - Beta",
@@ -93,18 +93,18 @@ setuptools.setup(
         "Operating System :: Microsoft :: Windows",
         "Topic :: Software Development :: Quality Assurance",
         "Topic :: Software Development :: Bug Tracking",
-        "Topic :: System :: Logging"
+        "Topic :: System :: Logging",
     ],
     python_requires=">=3.7",
     install_requires=["objprint>=0.1.3"],
     extras_require={
-        "full": ["rich", "orjson"]
+        "full": ["rich", "orjson"],
     },
     entry_points={
         "console_scripts": [
             "viztracer = viztracer:main",
             "vizviewer = viztracer:viewer_main",
-            "vdb = viztracer:sim_main"
-        ]
+            "vdb = viztracer:sim_main",
+        ],
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
-import setuptools
-import sys
 import platform
+import sys
+
+import setuptools
 
 with open("README.md") as f:
     long_description = f.read()

--- a/src/viztracer/__init__.py
+++ b/src/viztracer/__init__.py
@@ -5,7 +5,7 @@ __version__ = "0.15.6"
 
 
 from .cellmagic import load_ipython_extension
-from .decorator import ignore_function, trace_and_save, log_sparse
+from .decorator import ignore_function, log_sparse, trace_and_save
 from .main import main
 from .simulator import main as sim_main
 from .viewer import viewer_main
@@ -13,7 +13,6 @@ from .vizcounter import VizCounter
 from .vizlogging import VizLoggingHandler
 from .vizobject import VizObject
 from .viztracer import VizTracer, get_tracer
-
 
 __all__ = [
     "__version__",

--- a/src/viztracer/__init__.py
+++ b/src/viztracer/__init__.py
@@ -27,5 +27,5 @@ __all__ = [
     "VizCounter",
     "VizObject",
     "VizLoggingHandler",
-    "load_ipython_extension"
+    "load_ipython_extension",
 ]

--- a/src/viztracer/__main__.py
+++ b/src/viztracer/__main__.py
@@ -3,6 +3,5 @@
 
 from .main import main
 
-
 if __name__ == '__main__':
     main()

--- a/src/viztracer/attach.py
+++ b/src/viztracer/attach.py
@@ -4,10 +4,11 @@
 
 import base64
 import builtins
-from dataclasses import dataclass
 import gc
 import json
 import sys
+from dataclasses import dataclass
+
 from .viztracer import VizTracer, get_tracer
 
 

--- a/src/viztracer/attach_process/add_code_to_python_process.py
+++ b/src/viztracer/attach_process/add_code_to_python_process.py
@@ -1,6 +1,6 @@
 # type: ignore
 
-r'''
+r"""
 Copyright: Brainwy Software Ltda.
 
 License: EPL.
@@ -66,7 +66,7 @@ Other references:
 To build the dlls needed on windows, visual studio express 13 was used (see compile_dll.bat)
 
 See: attach_pydevd.py to attach the pydev debugger to a running python process.
-'''
+"""
 
 # Note: to work with nasm compiling asm to code and decompiling to see asm with shellcode:
 # x:\nasm\nasm-2.07-win32\nasm-2.07\nasm.exe
@@ -105,9 +105,9 @@ def _create_win_event(name):
     class _WinEvent():
 
         def wait_for_event_set(self, timeout=None):
-            '''
+            """
             :param timeout: in seconds
-            '''
+            """
             if timeout is None:
                 timeout = 0xFFFFFFFF
             else:
@@ -230,8 +230,8 @@ def get_target_filename(is_target_process_64=None, prefix=None, extension=None):
         if filename is None:
             print(
                 'Unable to attach to process in arch: %s (did not find %s in %s).' % (
-                    arch, expected_name, libdir
-                )
+                    arch, expected_name, libdir,
+                ),
             )
             return None
 
@@ -316,10 +316,10 @@ def run_python_code_windows(pid, python_code, connect_debugger_tracing=False, sh
 
 @contextmanager
 def _acquire_mutex(mutex_name, timeout):
-    '''
+    """
     Only one process may be attaching to a pid, so, create a system mutex
     to make sure this holds in practice.
-    '''
+    """
     from winappdbg.win32.defines import ERROR_ALREADY_EXISTS
     from winappdbg.win32.kernel32 import CloseHandle, CreateMutex, GetLastError
 
@@ -419,7 +419,7 @@ def run_python_code_linux(pid, python_code, connect_debugger_tracing=False, show
         f"--eval-command='call (void*)dlopen(\"{target_dll}\", 2)'",
         f"--eval-command='sharedlibrary {target_dll_name}'",
         "--eval-command='call (int)DoAttach(%s, \"%s\", %s)'" % (
-            is_debug, python_code, show_debug_info)
+            is_debug, python_code, show_debug_info),
     ])
 
     # print ' '.join(cmd)
@@ -474,7 +474,7 @@ def run_python_code_mac(pid, python_code, connect_debugger_tracing=False, show_d
         # '--arch',
         # arch,
         '--script-language',
-        'Python'
+        'Python',
         #         '--batch-silent',
     ]
 
@@ -482,7 +482,7 @@ def run_python_code_mac(pid, python_code, connect_debugger_tracing=False, show_d
         "-o 'process attach --pid %d'" % pid,
         f"-o 'command script import \"{lldb_prepare_file}\"'",
         "-o 'load_lib_and_attach \"%s\" %s \"%s\" %s'" % (target_dll,
-            is_debug, python_code, show_debug_info),
+                                                          is_debug, python_code, show_debug_info),
     ])
 
     cmd.extend([
@@ -504,7 +504,7 @@ def run_python_code_mac(pid, python_code, connect_debugger_tracing=False, show_d
         env=env,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
-        )
+    )
     # print('Running lldb in target process.')
     out, err = p.communicate()
     # print('stdout: %s' % (out,))

--- a/src/viztracer/attach_process/add_code_to_python_process.py
+++ b/src/viztracer/attach_process/add_code_to_python_process.py
@@ -73,13 +73,13 @@ See: attach_pydevd.py to attach the pydev debugger to a running python process.
 # nasm.asm&x:\nasm\nasm-2.07-win32\nasm-2.07\ndisasm.exe -b arch nasm
 import ctypes
 import os
+import platform
 import struct
 import subprocess
 import sys
 import time
-from contextlib import contextmanager
-import platform
 import traceback
+from contextlib import contextmanager
 
 try:
     TimeoutError = TimeoutError  # @ReservedAssignment
@@ -91,7 +91,8 @@ except NameError:
 
 @contextmanager
 def _create_win_event(name):
-    from winappdbg.win32.kernel32 import CreateEventA, WaitForSingleObject, CloseHandle
+    from winappdbg.win32.kernel32 import (CloseHandle, CreateEventA,
+                                          WaitForSingleObject)
 
     manual_reset = False  # i.e.: after someone waits it, automatically set to False.
     initial_state = False
@@ -319,8 +320,8 @@ def _acquire_mutex(mutex_name, timeout):
     Only one process may be attaching to a pid, so, create a system mutex
     to make sure this holds in practice.
     '''
-    from winappdbg.win32.kernel32 import CreateMutex, GetLastError, CloseHandle
     from winappdbg.win32.defines import ERROR_ALREADY_EXISTS
+    from winappdbg.win32.kernel32 import CloseHandle, CreateMutex, GetLastError
 
     initial_time = time.time()
     while True:
@@ -342,12 +343,8 @@ def _acquire_mutex(mutex_name, timeout):
 def _win_write_to_shared_named_memory(python_code, pid):
     # Use the definitions from winappdbg when possible.
     from winappdbg.win32 import defines
-    from winappdbg.win32.kernel32 import (
-        CreateFileMapping,
-        MapViewOfFile,
-        CloseHandle,
-        UnmapViewOfFile,
-    )
+    from winappdbg.win32.kernel32 import (CloseHandle, CreateFileMapping,
+                                          MapViewOfFile, UnmapViewOfFile)
 
     memmove = ctypes.cdll.msvcrt.memmove
     memmove.argtypes = [

--- a/src/viztracer/attach_process/add_code_to_python_process.py
+++ b/src/viztracer/attach_process/add_code_to_python_process.py
@@ -102,7 +102,7 @@ def _create_win_event(name):
     if not event:
         raise ctypes.WinError()
 
-    class _WinEvent(object):
+    class _WinEvent():
 
         def wait_for_event_set(self, timeout=None):
             '''

--- a/src/viztracer/attach_process/add_code_to_python_process.py
+++ b/src/viztracer/attach_process/add_code_to_python_process.py
@@ -576,4 +576,3 @@ if __name__ == '__main__':
             test()
         else:
             main(args)
-

--- a/src/viztracer/attach_process/linux_and_mac/lldb_prepare.py
+++ b/src/viztracer/attach_process/linux_and_mac/lldb_prepare.py
@@ -48,6 +48,3 @@ def __lldb_init_module(debugger, internal_dict):
                     # thread.Suspend()
     except:
         import traceback;traceback.print_exc()
-
-
-

--- a/src/viztracer/attach_process/linux_and_mac/lldb_prepare.py
+++ b/src/viztracer/attach_process/linux_and_mac/lldb_prepare.py
@@ -32,6 +32,7 @@ def load_lib_and_attach(debugger, command, result, internal_dict):
     if error:
         print(error)
 
+
 def __lldb_init_module(debugger, internal_dict):
     import lldb
 
@@ -47,4 +48,4 @@ def __lldb_init_module(debugger, internal_dict):
                     internal_dict['_thread_%d' % thread.GetThreadID()] = True
                     # thread.Suspend()
     except:
-        import traceback;traceback.print_exc()
+        import traceback; traceback.print_exc()

--- a/src/viztracer/attach_process/linux_and_mac/lldb_prepare.py
+++ b/src/viztracer/attach_process/linux_and_mac/lldb_prepare.py
@@ -20,7 +20,8 @@ def load_lib_and_attach(debugger, command, result, internal_dict):
 
     print(dll)
     target = debugger.GetSelectedTarget()
-    res = target.EvaluateExpression(f"(void*)dlopen(\"{dll}\", 2);", options)
+    res = target.EvaluateExpression("(void*)dlopen(\"%s\", 2);" % (
+        dll), options)
     error = res.GetError()
     if error:
         print(error)
@@ -31,7 +32,6 @@ def load_lib_and_attach(debugger, command, result, internal_dict):
     error = res.GetError()
     if error:
         print(error)
-
 
 def __lldb_init_module(debugger, internal_dict):
     import lldb
@@ -48,4 +48,7 @@ def __lldb_init_module(debugger, internal_dict):
                     internal_dict['_thread_%d' % thread.GetThreadID()] = True
                     # thread.Suspend()
     except:
-        import traceback; traceback.print_exc()
+        import traceback;traceback.print_exc()
+
+
+

--- a/src/viztracer/attach_process/linux_and_mac/lldb_prepare.py
+++ b/src/viztracer/attach_process/linux_and_mac/lldb_prepare.py
@@ -20,8 +20,7 @@ def load_lib_and_attach(debugger, command, result, internal_dict):
 
     print(dll)
     target = debugger.GetSelectedTarget()
-    res = target.EvaluateExpression("(void*)dlopen(\"%s\", 2);" % (
-        dll), options)
+    res = target.EvaluateExpression(f"(void*)dlopen(\"{dll}\", 2);", options)
     error = res.GetError()
     if error:
         print(error)

--- a/src/viztracer/cellmagic.py
+++ b/src/viztracer/cellmagic.py
@@ -2,17 +2,19 @@
 # For details: https://github.com/gaogaotiantian/viztracer/blob/master/NOTICE.txt
 
 try:
-    from IPython.core.magic import cell_magic, magics_class, Magics, needs_local_scope  # type: ignore
+    from IPython.core.magic import (Magics, cell_magic,  # type: ignore
+                                    magics_class, needs_local_scope)
 
     @magics_class
     class VizTracerMagics(Magics):
         @needs_local_scope
         @cell_magic
         def viztracer(self, line, cell, local_ns) -> None:
-            from .viztracer import VizTracer
-            from .viewer import ServerThread
             from IPython.display import display  # type: ignore
             from ipywidgets import Button  # type: ignore
+
+            from .viewer import ServerThread
+            from .viztracer import VizTracer
             code = self.shell.transform_cell(cell)
             file_path = "./viztracer_report.json"
             with VizTracer(verbose=0, output_file=file_path):

--- a/src/viztracer/code_monkey.py
+++ b/src/viztracer/code_monkey.py
@@ -162,19 +162,19 @@ class AstTransformer(ast.NodeTransformer):
             return self.get_add_variable_node(
                 name=f"{trigger} - {name}",
                 var_node=ast.Name(id=name, ctx=ast.Load()),
-                event=event
+                event=event,
             )
         elif self.inst_type == "log_func_exec":
             return self.get_add_func_exec_node(
                 name=f"{name}",
                 val=ast.Name(id=name, ctx=ast.Load()),
-                lineno=self.curr_lineno
+                lineno=self.curr_lineno,
             )
         elif self.inst_type == "log_func_entry":
             return self.get_add_variable_node(
                 name=f"{trigger} - {name}",
                 var_node=ast.Constant(value=f"{name} is called"),
-                event="instant"
+                event="instant",
             )
         else:
             raise ValueError(f"{name} is not supported")
@@ -190,7 +190,7 @@ class AstTransformer(ast.NodeTransformer):
         return self.get_add_variable_node(
             name=name,
             var_node=var_node,
-            event="instant"
+            event="instant",
         )
 
     def get_add_variable_node(self, name: str, var_node: ast.AST, event: str) -> ast.Expr:
@@ -199,15 +199,15 @@ class AstTransformer(ast.NodeTransformer):
                 func=ast.Attribute(
                     value=ast.Name(id="__viz_tracer__", ctx=ast.Load()),
                     attr="add_variable",
-                    ctx=ast.Load()
+                    ctx=ast.Load(),
                 ),
                 args=[
                     ast.Constant(value=name),
                     var_node,
-                    ast.Constant(value=event)
+                    ast.Constant(value=event),
                 ],
-                keywords=[]
-            )
+                keywords=[],
+            ),
         )
         return node_instrument
 
@@ -217,15 +217,15 @@ class AstTransformer(ast.NodeTransformer):
                 func=ast.Attribute(
                     value=ast.Name(id="__viz_tracer__", ctx=ast.Load()),
                     attr="add_func_exec",
-                    ctx=ast.Load()
+                    ctx=ast.Load(),
                 ),
                 args=[
                     ast.Constant(value=name),
                     ast.Name(id=name, ctx=ast.Load()),
-                    ast.Constant(value=lineno)
+                    ast.Constant(value=lineno),
                 ],
-                keywords=[]
-            )
+                keywords=[],
+            ),
         )
         return node_instrument
 
@@ -290,6 +290,7 @@ class SourceProcessor:
     """
     Pre-process comments like #!viztracer: log_instant("event")
     """
+
     def process(self, source: Any):
         if isinstance(source, bytes):
             source = source.decode("utf-8")
@@ -337,7 +338,7 @@ class SourceProcessor:
         # !viztracer: log_var("var", var) if var > 3
         (re.compile(r"(\s*)#\s*!viztracer:\s*(log_.*?\(.*\))\s*if\s+(.*?)\s*$"), line_transform_condition),
         # a = 3  # !viztracer: log if a != 3
-        (re.compile(r"(.*\S.*)#\s*!viztracer:\s*log\s*if\s+(.*?)\s*$"), inline_transform_condition)
+        (re.compile(r"(.*\S.*)#\s*!viztracer:\s*log\s*if\s+(.*?)\s*$"), inline_transform_condition),
     ]
 
 

--- a/src/viztracer/code_monkey.py
+++ b/src/viztracer/code_monkey.py
@@ -173,11 +173,11 @@ class AstTransformer(ast.NodeTransformer):
         elif self.inst_type == "log_func_entry":
             return self.get_add_variable_node(
                 name=f"{trigger} - {name}",
-                var_node=ast.Constant(value="{} is called".format(name)),
+                var_node=ast.Constant(value=f"{name} is called"),
                 event="instant"
             )
         else:
-            raise ValueError("{} is not supported".format(name))
+            raise ValueError(f"{name} is not supported")
 
     def get_instrument_node_by_node(self, trigger: str, node: Optional[ast.expr]) -> ast.Expr:
         var_node: ast.expr
@@ -248,25 +248,25 @@ class AstTransformer(ast.NodeTransformer):
             return node.id
         elif isinstance(node, ast.Constant):
             if isinstance(node.value, str):
-                return "'{}'".format(node.value)
+                return f"'{node.value}'"
             else:
-                return "{}".format(node.value)
+                return f"{node.value}"
         elif isinstance(node, ast.Num):
-            return "{}".format(node.n)
+            return f"{node.n}"
         elif isinstance(node, ast.Str):
-            return "'{}'".format(node.s)
+            return f"'{node.s}'"
         elif isinstance(node, ast.Attribute):
-            return "{}.{}".format(self.get_string_of_expr(node.value), node.attr)
+            return f"{self.get_string_of_expr(node.value)}.{node.attr}"
         elif isinstance(node, ast.Subscript):
-            return "{}[{}]".format(self.get_string_of_expr(node.value), self.get_string_of_expr(node.slice))
+            return f"{self.get_string_of_expr(node.value)}[{self.get_string_of_expr(node.slice)}]"
         elif isinstance(node, ast.Call):
-            return "{}()".format(self.get_string_of_expr(node.func))
+            return f"{self.get_string_of_expr(node.func)}()"
         elif isinstance(node, ast.Starred):
-            return "*{}".format(self.get_string_of_expr(node.value))
+            return f"*{self.get_string_of_expr(node.value)}"
         elif isinstance(node, ast.Tuple):
-            return "({})".format(",".join([self.get_string_of_expr(elt) for elt in node.elts]))
+            return f"({','.join([self.get_string_of_expr(elt) for elt in node.elts])})"
         elif isinstance(node, ast.List):
-            return "[{}]".format(",".join([self.get_string_of_expr(elt) for elt in node.elts]))
+            return f"[{','.join([self.get_string_of_expr(elt) for elt in node.elts])}]"
         elif sys.version_info < (3, 9) and isinstance(node, ast.Index):
             return self.get_string_of_expr(node.value)
         elif isinstance(node, ast.Slice):
@@ -274,11 +274,11 @@ class AstTransformer(ast.NodeTransformer):
             upper = self.get_string_of_expr(node.upper) if "upper" in node._fields and node.upper else ""
             step = self.get_string_of_expr(node.step) if "step" in node._fields and node.step else ""
             if step:
-                return "{}:{}:{}".format(lower, upper, step)
+                return f"{lower}:{upper}:{step}"
             elif upper:
-                return "{}:{}".format(lower, upper)
+                return f"{lower}:{upper}"
             else:
-                return "{}:".format(lower)
+                return f"{lower}:"
         elif sys.version_info < (3, 9) and isinstance(node, ast.ExtSlice):
             return ",".join([self.get_string_of_expr(dim) for dim in node.dims])
         color_print("WARNING", "Unexpected node type {} for ast.Assign. \

--- a/src/viztracer/code_monkey.py
+++ b/src/viztracer/code_monkey.py
@@ -3,9 +3,9 @@
 
 import ast
 import copy
-from functools import reduce
 import re
 import sys
+from functools import reduce
 from typing import Any, Callable, Dict, List, Optional, Union
 
 from .util import color_print

--- a/src/viztracer/decorator.py
+++ b/src/viztracer/decorator.py
@@ -95,7 +95,7 @@ def log_sparse(func: Optional[Callable] = None, stack_depth: int = 0) -> Callabl
                 "name": f"{code.co_name} ({code.co_filename}:{code.co_firstlineno})",
                 "ts": start,
                 "dur": dur,
-                "cat": "FEE"
+                "cat": "FEE",
             }
             tracer.add_raw(raw_data)
             return ret

--- a/src/viztracer/decorator.py
+++ b/src/viztracer/decorator.py
@@ -45,7 +45,7 @@ def trace_and_save(method: Optional[Callable] = None, output_dir: str = "./", **
             tracer.stop()
             if not os.path.exists(output_dir):
                 os.mkdir(output_dir)
-            file_name = os.path.join(output_dir, "result_{}_{}.json".format(func.__name__, int(100000 * time.time())))
+            file_name = os.path.join(output_dir, f"result_{func.__name__}_{int(100000 * time.time())}.json")
             tracer.fork_save(file_name)
             tracer.cleanup()
             return ret

--- a/src/viztracer/event_base.py
+++ b/src/viztracer/event_base.py
@@ -46,7 +46,7 @@ class _EventBase:
 
     def _viztracer_set_config(self, key: str, value: Any) -> None:
         if key not in self._viztracer_config:
-            raise ValueError("No config named {}".format(key))
+            raise ValueError(f"No config named {key}")
         self._viztracer_config[key] = value
 
     def config(self, key: str, value: Any) -> None:
@@ -61,7 +61,7 @@ class _EventBase:
     @staticmethod
     def triggerlog(method: Optional[Callable] = None, when: str = "after") -> Callable:
         if when not in ["after", "before", "both"]:
-            raise ValueError("when has to be one of 'after', 'before' or 'both', not {}".format(when))
+            raise ValueError(f"when has to be one of 'after', 'before' or 'both', not {when}")
 
         def inner(func: Callable) -> Callable:
 

--- a/src/viztracer/event_base.py
+++ b/src/viztracer/event_base.py
@@ -15,7 +15,7 @@ class _EventBase:
         self._viztracer_config: Dict = {
             "trigger_on_change": True,
             "include_attributes": [],
-            "exclude_attributes": []
+            "exclude_attributes": [],
         }
 
         for key in kwargs:

--- a/src/viztracer/flamegraph.py
+++ b/src/viztracer/flamegraph.py
@@ -44,7 +44,7 @@ class FlameGraph:
     def parse(self, trace_data: Dict[str, Any]) -> None:
         func_trees: Dict[str, FuncTree] = {}
         for data in trace_data["traceEvents"]:
-            key = "p{}_t{}".format(data["pid"], data["tid"])
+            key = f"p{data['pid']}_t{data['tid']}"
             if key in func_trees:
                 tree = func_trees[key]
             else:

--- a/src/viztracer/flamegraph.py
+++ b/src/viztracer/flamegraph.py
@@ -59,7 +59,7 @@ class FlameGraph:
 
     def dump_to_perfetto(self) -> List[Dict[str, Any]]:
         """
-        reformat data to what perfetto likes
+        Reformat data to what perfetto likes
         private _functionProfileDetails?: FunctionProfileDetails[]
         export interface FunctionProfileDetails {
           name?: string;
@@ -101,7 +101,7 @@ class FlameGraph:
                     "selfSize": node.value - sum((n.value for n in node.children.values())),
                     "mapping": f"{node.count}",
                     "merged": False,
-                    "highlighted": False
+                    "highlighted": False,
                 })
                 for n in node.children.values():
                     q.put((n, idx, depth + 1))
@@ -109,7 +109,7 @@ class FlameGraph:
 
             detail = {
                 "name": name,
-                "flamegraph": flamegraph
+                "flamegraph": flamegraph,
             }
             ret.append(detail)
         return ret

--- a/src/viztracer/functree.py
+++ b/src/viztracer/functree.py
@@ -1,8 +1,8 @@
 # Licensed under the Apache License: http://www.apache.org/licenses/LICENSE-2.0
 # For details: https://github.com/gaogaotiantian/viztracer/blob/master/NOTICE.txt
 
-import copy
 import bisect
+import copy
 import re
 from typing import Any, Dict, Generator, List, Optional
 

--- a/src/viztracer/main.py
+++ b/src/viztracer/main.py
@@ -393,7 +393,7 @@ class VizUI:
         file_name = command[0]
         search_result = self.search_file(file_name)
         if not search_result:
-            return False, "No such file as {}".format(file_name)
+            return False, f"No such file as {file_name}"
         file_name = search_result
         with open(file_name, "rb") as f:
             code_string = f.read()
@@ -517,7 +517,7 @@ class VizUI:
             return False, f"Failed to inject code [err {retcode}]"
 
         print("Use the following command to open the report:")
-        color_print("OKGREEN", "vizviewer {}".format(self.init_kwargs["output_file"]))
+        color_print("OKGREEN", f"vizviewer {self.init_kwargs['output_file']}")
 
         return True, None
 

--- a/src/viztracer/main.py
+++ b/src/viztracer/main.py
@@ -265,7 +265,7 @@ class VizUI:
             "min_duration": min_duration,
             "sanitize_function_name": options.sanitize_function_name,
             "dump_raw": True,
-            "minimize_memory": options.minimize_memory
+            "minimize_memory": options.minimize_memory,
         }
 
         return True, None
@@ -370,7 +370,7 @@ class VizUI:
         code = "run_module(modname, run_name='__main__', alter_sys=True)"
         global_dict = {
             "run_module": runpy.run_module,
-            "modname": self.options.module
+            "modname": self.options.module,
         }
         sys.argv = [self.options.module] + self.command[:]
         sys.path.insert(0, os.getcwd())
@@ -501,7 +501,7 @@ class VizUI:
             "file_info": True,
             "register_global": True,
             "dump_raw": False,
-            "verbose": 1 if self.verbose != 0 else 0
+            "verbose": 1 if self.verbose != 0 else 0,
         })
         b64s = base64.urlsafe_b64encode(json.dumps(self.init_kwargs).encode("ascii")).decode("ascii")
         start_code = f"import viztracer.attach; viztracer.attach.start_attach(\\\"{b64s}\\\")"

--- a/src/viztracer/main.py
+++ b/src/viztracer/main.py
@@ -21,8 +21,7 @@ from typing import Any, Dict, List, Optional, Tuple
 from viztracer.vcompressor import VCompressor
 
 from . import __version__
-from .attach_process.add_code_to_python_process import \
-    run_python_code  # type: ignore
+from .attach_process.add_code_to_python_process import run_python_code  # type: ignore
 from .code_monkey import CodeMonkey
 from .patch import install_all_hooks
 from .report_builder import ReportBuilder

--- a/src/viztracer/main.py
+++ b/src/viztracer/main.py
@@ -18,16 +18,16 @@ import time
 import types
 from typing import Any, Dict, List, Optional, Tuple
 
+from viztracer.vcompressor import VCompressor
+
 from . import __version__
-from .attach_process.add_code_to_python_process import run_python_code  # type: ignore
+from .attach_process.add_code_to_python_process import \
+    run_python_code  # type: ignore
 from .code_monkey import CodeMonkey
 from .patch import install_all_hooks
 from .report_builder import ReportBuilder
-from .util import time_str_to_us, color_print, same_line_print, pid_exists
+from .util import color_print, pid_exists, same_line_print, time_str_to_us
 from .viztracer import VizTracer
-
-from viztracer.vcompressor import VCompressor
-
 
 # For all the procedures in VizUI, return a tuple as the result
 # The first element bool indicates whether the procedure succeeds

--- a/src/viztracer/patch.py
+++ b/src/viztracer/patch.py
@@ -4,11 +4,11 @@
 from __future__ import annotations
 
 import functools
-from multiprocessing import Process
 import os
 import re
 import sys
 import textwrap
+from multiprocessing import Process
 from typing import Any, Callable, Dict, List, Sequence, Union, no_type_check
 
 from .viztracer import VizTracer
@@ -99,8 +99,8 @@ def patch_multiprocessing(tracer: VizTracer, args: List[str]) -> None:
         if tracer._afterfork_cb:
             tracer._afterfork_cb(tracer, *tracer._afterfork_args, **tracer._afterfork_kwargs)
 
-    from multiprocessing.util import register_after_fork  # type: ignore
     import multiprocessing.spawn
+    from multiprocessing.util import register_after_fork  # type: ignore
 
     register_after_fork(tracer, func_after_fork)
 
@@ -155,9 +155,9 @@ class SpawnProcess:
 
 
 def patch_spawned_process(viztracer_kwargs: Dict[str, Any], cmdline_args: List[str]):
-    from multiprocessing import reduction, process  # type: ignore
-    from multiprocessing.spawn import prepare
     import multiprocessing.spawn
+    from multiprocessing import process, reduction  # type: ignore
+    from multiprocessing.spawn import prepare
 
     @no_type_check
     @functools.wraps(multiprocessing.spawn._main)

--- a/src/viztracer/patch.py
+++ b/src/viztracer/patch.py
@@ -107,9 +107,9 @@ def patch_multiprocessing(tracer: VizTracer, args: List[str]) -> None:
     # For spawn process
     @functools.wraps(multiprocessing.spawn.get_command_line)
     def get_command_line(**kwds) -> List[str]:
-        '''
+        """
         Returns prefix of command line used for spawning a child process
-        '''
+        """
         if getattr(sys, 'frozen', False):  # pragma: no cover
             return ([sys.executable, '--multiprocessing-fork']
                     + ['%s=%r' % item for item in kwds.items()])

--- a/src/viztracer/prog_snapshot.py
+++ b/src/viztracer/prog_snapshot.py
@@ -234,7 +234,7 @@ class ProgSnapshot:
         elif ph == "M":
             return
         else:
-            print("Unsupported event type: {}".format(ph))
+            print(f"Unsupported event type: {ph}")
             return
 
     def check_version(self, version):
@@ -436,9 +436,9 @@ class ProgSnapshot:
         forest = self.func_trees[curr_tree.pid]
         for tid in forest:
             if tid == curr_tree.tid:
-                self.p("> {}".format(tid))
+                self.p(f"> {tid}")
             else:
-                self.p("  {}".format(tid))
+                self.p(f"  {tid}")
 
         return True, None
 
@@ -446,9 +446,9 @@ class ProgSnapshot:
         curr_tree = self.curr_tree
         for pid in self.func_trees:
             if pid == curr_tree.pid:
-                self.p("> {}".format(pid))
+                self.p(f"> {pid}")
             else:
-                self.p("  {}".format(pid))
+                self.p(f"  {pid}")
 
         return True, None
 

--- a/src/viztracer/prog_snapshot.py
+++ b/src/viztracer/prog_snapshot.py
@@ -109,7 +109,7 @@ class CounterEvents:
         args.update(event["args"])
         self._events.append({
             "ts": event["ts"],
-            "args": args
+            "args": args,
         })
 
     def normalize(self, first_ts):
@@ -135,7 +135,7 @@ class ObjectEvents:
                 "id": event["id"],
                 "name": event["name"],
                 "snapshots": [
-                ]
+                ],
             }
             self._objects[event["id"]] = entry
 
@@ -144,12 +144,12 @@ class ObjectEvents:
         if event["ph"] in ["N", "D"]:
             entry["snapshots"].append({
                 "ts": event["ts"],
-                "args": None
+                "args": None,
             })
         elif event["ph"] == "O":
             entry["snapshots"].append({
                 "ts": event["ts"],
-                "args": event["args"]["snapshot"]
+                "args": event["args"]["snapshot"],
             })
         else:  # pragma: no cover
             raise ValueError("Unexpected type for object event")

--- a/src/viztracer/report_builder.py
+++ b/src/viztracer/report_builder.py
@@ -5,15 +5,16 @@ try:
     import orjson  # type: ignore
 except ImportError:
     import json
+
 import gzip
 import os
 import re
-from string import Template
 import sys
-from typing import Any, Dict, List, Optional, Sequence, Tuple, Union, TextIO
+from string import Template
+from typing import Any, Dict, List, Optional, Sequence, TextIO, Tuple, Union
 
-from .util import color_print, same_line_print
 from . import __version__
+from .util import color_print, same_line_print
 
 
 def get_json(data: Union[Dict, str]) -> Dict[str, Any]:

--- a/src/viztracer/report_builder.py
+++ b/src/viztracer/report_builder.py
@@ -210,6 +210,6 @@ class ReportBuilder:
                     report_abspath = os.path.abspath(msg_args["output_file"])
                     print("Use the following command to open the report:")
                     if " " in report_abspath:
-                        color_print("OKGREEN", "vizviewer \"{}\"".format(report_abspath))
+                        color_print("OKGREEN", f"vizviewer \"{report_abspath}\"")
                     else:
-                        color_print("OKGREEN", "vizviewer {}".format(report_abspath))
+                        color_print("OKGREEN", f"vizviewer {report_abspath}")

--- a/src/viztracer/simulator.py
+++ b/src/viztracer/simulator.py
@@ -120,7 +120,7 @@ class Simulator:
         elif args[0] in ["quit", "exit", "q"]:
             sys.exit(0)
         else:
-            print("Invalid command: {}".format(cmd))
+            print(f"Invalid command: {cmd}")
             return
 
         if success:

--- a/src/viztracer/tracer.py
+++ b/src/viztracer/tracer.py
@@ -3,10 +3,11 @@
 
 import builtins
 import gc
-from io import StringIO
 import os
 import sys
+from io import StringIO
 from typing import Any, Dict, Optional, Sequence, Union
+
 import viztracer.snaptrace as snaptrace  # type: ignore
 
 from . import __version__

--- a/src/viztracer/tracer.py
+++ b/src/viztracer/tracer.py
@@ -251,7 +251,7 @@ class _VizTracer:
             "log_func_args": self.log_func_args,
             "log_async": self.log_async,
             "trace_self": self.trace_self,
-            "min_duration": self.min_duration
+            "min_duration": self.min_duration,
         }
 
         self._tracer.config(**cfg)
@@ -332,7 +332,7 @@ class _VizTracer:
                 args = {
                     "collecting": 1,
                     "collected": 0,
-                    "uncollectable": 0
+                    "uncollectable": 0,
                 }
                 self.add_counter("garbage collection", args)
                 self.gc_start_args = args
@@ -343,7 +343,7 @@ class _VizTracer:
                 self.add_counter("garbage collection", {
                     "collecting": 0,
                     "collected": 0,
-                    "uncollectable": 0
+                    "uncollectable": 0,
                 })
 
     def add_func_exec(self, name: str, val: Any, lineno: int) -> None:
@@ -370,8 +370,8 @@ class _VizTracer:
                 "traceEvents": self._tracer.load(),
                 "viztracer_metadata": {
                     "version": __version__,
-                    "overflow": False
-                }
+                    "overflow": False,
+                },
             }
             metadata_count = 0
             for d in self.data["traceEvents"]:

--- a/src/viztracer/tracer.py
+++ b/src/viztracer/tracer.py
@@ -66,11 +66,11 @@ class _VizTracer:
             try:
                 self.__max_stack_depth = int(max_stack_depth)
             except ValueError:
-                raise ValueError("Error when trying to convert max_stack_depth {} to integer.".format(max_stack_depth))
+                raise ValueError(f"Error when trying to convert max_stack_depth {max_stack_depth} to integer.")
         elif isinstance(max_stack_depth, int):
             self.__max_stack_depth = max_stack_depth
         else:
-            raise ValueError("Error when trying to convert max_stack_depth {} to integer.".format(max_stack_depth))
+            raise ValueError(f"Error when trying to convert max_stack_depth {max_stack_depth} to integer.")
         self.config()
 
     @property
@@ -116,7 +116,7 @@ class _VizTracer:
         if isinstance(ignore_c_function, bool):
             self.__ignore_c_function = ignore_c_function
         else:
-            raise ValueError("ignore_c_function needs to be True or False, not {}".format(ignore_c_function))
+            raise ValueError(f"ignore_c_function needs to be True or False, not {ignore_c_function}")
         self.config()
 
     @property
@@ -128,7 +128,7 @@ class _VizTracer:
         if isinstance(ignore_frozen, bool):
             self.__ignore_frozen = ignore_frozen
         else:
-            raise ValueError("ignore_frozen needs to be True or False, not {}".format(ignore_frozen))
+            raise ValueError(f"ignore_frozen needs to be True or False, not {ignore_frozen}")
         self.config()
 
     @property
@@ -140,7 +140,7 @@ class _VizTracer:
         if isinstance(log_func_retval, bool):
             self.__log_func_retval = log_func_retval
         else:
-            raise ValueError("log_func_retval needs to be True or False, not {}".format(log_func_retval))
+            raise ValueError(f"log_func_retval needs to be True or False, not {log_func_retval}")
         self.config()
 
     @property
@@ -152,7 +152,7 @@ class _VizTracer:
         if isinstance(log_async, bool):
             self.__log_async = log_async
         else:
-            raise ValueError("log_async needs to be True or False, not {}".format(log_async))
+            raise ValueError(f"log_async needs to be True or False, not {log_async}")
         self.config()
 
     @property
@@ -164,7 +164,7 @@ class _VizTracer:
         if isinstance(log_print, bool):
             self.__log_print = log_print
         else:
-            raise ValueError("log_print needs to be True or False, not {}".format(log_print))
+            raise ValueError(f"log_print needs to be True or False, not {log_print}")
 
     @property
     def log_func_args(self) -> bool:
@@ -175,7 +175,7 @@ class _VizTracer:
         if isinstance(log_func_args, bool):
             self.__log_func_args = log_func_args
         else:
-            raise ValueError("log_func_args needs to be True or False, not {}".format(log_func_args))
+            raise ValueError(f"log_func_args needs to be True or False, not {log_func_args}")
         self.config()
 
     @property
@@ -191,7 +191,7 @@ class _VizTracer:
             elif self.add_garbage_collection in gc.callbacks:
                 gc.callbacks.remove(self.add_garbage_collection)
         else:
-            raise ValueError("log_gc needs to be True or False, not {}".format(log_gc))
+            raise ValueError(f"log_gc needs to be True or False, not {log_gc}")
 
     @property
     def vdb(self) -> bool:
@@ -202,7 +202,7 @@ class _VizTracer:
         if isinstance(vdb, bool):
             self.__vdb = vdb
         else:
-            raise ValueError("vdb needs to be True or False, not {}".format(vdb))
+            raise ValueError(f"vdb needs to be True or False, not {vdb}")
         self.config()
 
     @property
@@ -215,11 +215,11 @@ class _VizTracer:
             try:
                 self.__verbose = int(verbose)
             except ValueError:
-                raise ValueError("Verbose needs to be an integer, not {}".format(verbose))
+                raise ValueError(f"Verbose needs to be an integer, not {verbose}")
         elif isinstance(verbose, int):
             self.__verbose = verbose
         else:
-            raise ValueError("Verbose needs to be an integer, not {}".format(verbose))
+            raise ValueError(f"Verbose needs to be an integer, not {verbose}")
         self.config()
 
     @property
@@ -231,7 +231,7 @@ class _VizTracer:
         if isinstance(min_duration, int) or isinstance(min_duration, float):
             self.__min_duration = float(min_duration)
         else:
-            raise ValueError("duration needs to be a float, not {}".format(min_duration))
+            raise ValueError(f"duration needs to be a float, not {min_duration}")
         self.config()
 
     def config(self) -> None:
@@ -307,9 +307,9 @@ class _VizTracer:
                 if isinstance(var, (int, float)):
                     self.add_counter(name, {name: var})
                 else:
-                    raise ValueError("{}({}) is not a number".format(name, var))
+                    raise ValueError(f"{name}({var}) is not a number")
             else:
-                raise ValueError("{} is not supported".format(event))
+                raise ValueError(f"{event} is not supported")
 
     def add_counter(self, name: str, args: Dict[str, Any]) -> None:
         if self.enable:
@@ -347,7 +347,7 @@ class _VizTracer:
                 })
 
     def add_func_exec(self, name: str, val: Any, lineno: int) -> None:
-        exec_line = "({}) {} = {}".format(lineno, name, val)
+        exec_line = f"({lineno}) {name} = {val}"
         curr_args = self._tracer.getfunctionarg()
         if not curr_args:
             self._tracer.addfunctionarg("exec_steps", [exec_line])

--- a/src/viztracer/util.py
+++ b/src/viztracer/util.py
@@ -12,9 +12,9 @@ from typing import Union
 def size_fmt(num: Union[int, float], suffix: str = 'B') -> str:
     for unit in ['', 'Ki', 'Mi', 'Gi']:
         if abs(num) < 1024.0:
-            return "%3.1f%s%s" % (num, unit, suffix)
+            return f"{num:3.1f}{unit}{suffix}"
         num /= 1024.0
-    return "%.1f%s%s" % (num, 'Ti', suffix)
+    return f"{num:.1f}{'Ti'}{suffix}"
 
 
 class _bcolors:

--- a/src/viztracer/viewer.py
+++ b/src/viztracer/viewer.py
@@ -76,7 +76,7 @@ class PerfettoHandler(HttpHandler):
         self.server_thread.notify_active()
         if self.path.endswith("vizviewer_info"):
             info = {
-                "is_flamegraph": self.server_thread.flamegraph
+                "is_flamegraph": self.server_thread.flamegraph,
             }
             self.send_response(200)
             self.send_header("Content-type", "application/json")
@@ -239,9 +239,9 @@ class ExternalProcessorProcess:
                 sys.executable,
                 self.trace_processor_path,
                 self.path,
-                "-D"
+                "-D",
             ],
-            stderr=subprocess.PIPE
+            stderr=subprocess.PIPE,
         )
         atexit.register(self.stop)
         self._wait_start()
@@ -360,12 +360,9 @@ class ServerThread(threading.Thread):
 
     def is_port_in_use(self) -> bool:
         with contextlib.closing(
-            socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            socket.socket(socket.AF_INET, socket.SOCK_STREAM),
         ) as sock:
-            if sock.connect_ex(('127.0.0.1', self.port)) == 0:
-                return True
-            else:
-                return False
+            return sock.connect_ex(('127.0.0.1', self.port)) == 0
 
 
 class DirectoryViewer:
@@ -500,7 +497,7 @@ def viewer_main() -> int:
                 server_only=options.server_only,
                 flamegraph=options.flamegraph,
                 timeout=options.timeout,
-                use_external_processor=options.use_external_processor
+                use_external_processor=options.use_external_processor,
             )
             directory_viewer.run()
         finally:
@@ -515,7 +512,7 @@ def viewer_main() -> int:
                 once=options.once,
                 flamegraph=options.flamegraph,
                 timeout=options.timeout,
-                use_external_processor=options.use_external_processor
+                use_external_processor=options.use_external_processor,
             )
             server.start()
             server.ready.wait()

--- a/src/viztracer/viewer.py
+++ b/src/viztracer/viewer.py
@@ -6,7 +6,6 @@ import atexit
 import contextlib
 import functools
 import html
-from http import HTTPStatus
 import http.server
 import io
 import json
@@ -17,11 +16,11 @@ import subprocess
 import sys
 import threading
 import time
-from typing import Any, Callable, Dict, List, Optional
 import urllib.parse
+from http import HTTPStatus
+from typing import Any, Callable, Dict, List, Optional
 
 from .flamegraph import FlameGraph
-
 
 dir_lock = threading.Lock()
 

--- a/src/viztracer/viewer.py
+++ b/src/viztracer/viewer.py
@@ -184,14 +184,14 @@ class DirectoryHandler(HttpHandler):
             displaypath = urllib.parse.unquote(path)
         displaypath = html.escape(displaypath, quote=False)
         enc = sys.getfilesystemencoding()
-        title = 'Directory listing for %s' % displaypath
+        title = f'Directory listing for {displaypath}'
         r.append('<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" '
                  '"http://www.w3.org/TR/html4/strict.dtd">')
         r.append('<html>\n<head>')
         r.append('<meta http-equiv="Content-Type" '
                  'content="text/html; charset=%s">' % enc)
-        r.append('<title>%s</title>\n</head>' % title)
-        r.append('<body>\n<h1>%s</h1>' % title)
+        r.append(f'<title>{title}</title>\n</head>')
+        r.append(f'<body>\n<h1>{title}</h1>')
         r.append('<hr>\n<ul>')
         for name in list:
             fullname = os.path.join(path, name)
@@ -223,7 +223,7 @@ class DirectoryHandler(HttpHandler):
         f.write(encoded)
         f.seek(0)
         self.send_response(HTTPStatus.OK)
-        self.send_header("Content-type", "text/html; charset=%s" % enc)
+        self.send_header("Content-type", f"text/html; charset={enc}")
         self.send_header("Content-Length", str(len(encoded)))
         self.end_headers()
         return f

--- a/src/viztracer/viewer.py
+++ b/src/viztracer/viewer.py
@@ -541,4 +541,4 @@ def viewer_main() -> int:
 
 
 if __name__ == "__main__":
-    exit(viewer_main())
+    sys.exit(viewer_main())

--- a/src/viztracer/vizevent.py
+++ b/src/viztracer/vizevent.py
@@ -4,7 +4,6 @@
 
 from typing import TYPE_CHECKING
 
-
 if TYPE_CHECKING:
     from .viztracer import VizTracer  # pragma: no cover
 

--- a/src/viztracer/vizevent.py
+++ b/src/viztracer/vizevent.py
@@ -26,6 +26,6 @@ class VizEvent:
             "name": f"{self.event_name} ({self.file_name}:{self.lineno})",
             "ts": self.start,
             "dur": dur,
-            "cat": "FEE"
+            "cat": "FEE",
         }
         self._tracer.add_raw(raw_data)

--- a/src/viztracer/vizplugin.py
+++ b/src/viztracer/vizplugin.py
@@ -3,11 +3,10 @@
 
 
 import sys
-from typing import Dict, Optional, Sequence, Union, TYPE_CHECKING
+from typing import TYPE_CHECKING, Dict, Optional, Sequence, Union
 
 from . import __version__
-from .util import compare_version, color_print
-
+from .util import color_print, compare_version
 
 if TYPE_CHECKING:
     from .viztracer import VizTracer  # pragma: no cover

--- a/src/viztracer/vizplugin.py
+++ b/src/viztracer/vizplugin.py
@@ -74,7 +74,7 @@ class VizPluginManager:
         module = args[0]
         try:
             package = __import__(module)
-        except (ImportError, ModuleNotFoundError):
+        except (ImportError):
             print(f"There's no module named {module}, maybe you need to install it")
             sys.exit(1)
 

--- a/src/viztracer/viztracer.py
+++ b/src/viztracer/viztracer.py
@@ -3,11 +3,12 @@
 
 import builtins
 import multiprocessing
-import objprint  # type: ignore
 import os
 import signal
 import sys
 from typing import Any, Callable, Dict, Optional, Sequence, Tuple, Union
+
+import objprint  # type: ignore
 
 from .report_builder import ReportBuilder
 from .tracer import _VizTracer

--- a/src/viztracer/viztracer.py
+++ b/src/viztracer/viztracer.py
@@ -59,7 +59,7 @@ class VizTracer(_VizTracer):
             log_func_args=log_func_args,
             log_async=log_async,
             trace_self=trace_self,
-            min_duration=min_duration
+            min_duration=min_duration,
         )
         self._tracer: Any
         self.verbose = verbose
@@ -120,7 +120,7 @@ class VizTracer(_VizTracer):
             "pid_suffix": self.pid_suffix,
             "min_duration": self.min_duration,
             "dump_raw": self.dump_raw,
-            "minimize_memory": self.minimize_memory
+            "minimize_memory": self.minimize_memory,
         }
 
     def __enter__(self) -> "VizTracer":

--- a/src/viztracer/viztracer.py
+++ b/src/viztracer/viztracer.py
@@ -96,7 +96,7 @@ class VizTracer(_VizTracer):
         if type(pid_suffix) is bool:
             self.__pid_suffix = pid_suffix
         else:
-            raise ValueError("pid_suffix needs to be a boolean, not {}".format(pid_suffix))
+            raise ValueError(f"pid_suffix needs to be a boolean, not {pid_suffix}")
 
     @property
     def init_kwargs(self) -> Dict:

--- a/src/viztracer/web_dist/trace_processor
+++ b/src/viztracer/web_dist/trace_processor
@@ -121,7 +121,9 @@ def get_perfetto_prebuilt(tool_name, soft_fail=False, arch=None):
   # ~/.perfetto/prebuilts/$tool_name. On subsequent invocations it just runs the
   # cached version.
   def download_or_get_cached(file_name, url, sha256):
-    import os, hashlib, subprocess
+    import hashlib
+    import os
+    import subprocess
     dir = os.path.join(
         os.path.expanduser('~'), '.local', 'share', 'perfetto', 'prebuilts')
     os.makedirs(dir, exist_ok=True)
@@ -155,7 +157,9 @@ def get_perfetto_prebuilt(tool_name, soft_fail=False, arch=None):
     # --- end of download_or_get_cached() ---
 
   # --- get_perfetto_prebuilt() function starts here. ---
-  import os, platform, sys
+  import os
+  import platform
+  import sys
   plat = sys.platform.lower()
   machine = platform.machine().lower()
   manifest_entry = None
@@ -185,7 +189,8 @@ def get_perfetto_prebuilt(tool_name, soft_fail=False, arch=None):
 # END_SECTION_GENERATED_BY(roll-prebuilts)
 
 if __name__ == '__main__':
-  import sys, os
+  import os
+  import sys
   bin_path = get_perfetto_prebuilt(TOOL_NAME)
   os.execv(bin_path, [bin_path] + sys.argv[1:])
 

--- a/src/viztracer/web_dist/trace_processor
+++ b/src/viztracer/web_dist/trace_processor
@@ -121,9 +121,7 @@ def get_perfetto_prebuilt(tool_name, soft_fail=False, arch=None):
   # ~/.perfetto/prebuilts/$tool_name. On subsequent invocations it just runs the
   # cached version.
   def download_or_get_cached(file_name, url, sha256):
-    import hashlib
-    import os
-    import subprocess
+    import os, hashlib, subprocess
     dir = os.path.join(
         os.path.expanduser('~'), '.local', 'share', 'perfetto', 'prebuilts')
     os.makedirs(dir, exist_ok=True)
@@ -157,9 +155,7 @@ def get_perfetto_prebuilt(tool_name, soft_fail=False, arch=None):
     # --- end of download_or_get_cached() ---
 
   # --- get_perfetto_prebuilt() function starts here. ---
-  import os
-  import platform
-  import sys
+  import os, platform, sys
   plat = sys.platform.lower()
   machine = platform.machine().lower()
   manifest_entry = None
@@ -189,8 +185,7 @@ def get_perfetto_prebuilt(tool_name, soft_fail=False, arch=None):
 # END_SECTION_GENERATED_BY(roll-prebuilts)
 
 if __name__ == '__main__':
-  import os
-  import sys
+  import sys, os
   bin_path = get_perfetto_prebuilt(TOOL_NAME)
   os.execv(bin_path, [bin_path] + sys.argv[1:])
 

--- a/tests/archived/_test_prog_snapshot.py
+++ b/tests/archived/_test_prog_snapshot.py
@@ -2,9 +2,10 @@
 # For details: https://github.com/gaogaotiantian/viztracer/blob/master/NOTICE.txt
 
 import json
-from viztracer.prog_snapshot import ProgSnapshot
-from .base_tmpl import BaseTmpl
 
+from viztracer.prog_snapshot import ProgSnapshot
+
+from .base_tmpl import BaseTmpl
 
 test1_str = '{"traceEvents":[{"pid":7761,"tid":7761,"ts":23668655769.443,"dur":0.4,"name":"h (test.py:6)","caller_lineno":10,"ph":"X","cat":"FEE"},{"pid":7761,"tid":7761,"ts":23668655769.243,"dur":1.2,"name":"g (test.py:9)","caller_lineno":18,"ph":"X","cat":"FEE"},{"pid":7761,"tid":7761,"ts":23668655770.543,"dur":0.1,"name":"h (test.py:6)","caller_lineno":19,"ph":"X","cat":"FEE"},{"pid":7761,"tid":7761,"ts":23668655769.043,"dur":1.7,"name":"f (test.py:14)","caller_lineno":22,"ph":"X","cat":"FEE"},{"pid":7761,"tid":7761,"ts":23668655771.143,"dur":0.1,"name":"h (test.py:6)","caller_lineno":10,"ph":"X","cat":"FEE"},{"pid":7761,"tid":7761,"ts":23668655771.043,"dur":0.3,"name":"g (test.py:9)","caller_lineno":17,"ph":"X","cat":"FEE"},{"pid":7761,"tid":7761,"ts":23668655771.443,"dur":0.0,"name":"h (test.py:6)","caller_lineno":19,"ph":"X","cat":"FEE"},{"pid":7761,"tid":7761,"ts":23668655770.943,"dur":0.6,"name":"f (test.py:14)","caller_lineno":24,"ph":"X","cat":"FEE"},{"pid":7761,"tid":7761,"ts":23668655768.843,"dur":2.8,"name":"t (test.py:21)","caller_lineno":26,"ph":"X","cat":"FEE"},{"pid":7761,"tid":7761,"ts":23668655766.943,"dur":4.8,"name":"<module> (test.py:2)","caller_lineno":147,"ph":"X","cat":"FEE"},{"pid":7761,"tid":7761,"ts":23668655766.343,"dur":5.8,"name":"builtins.exec","caller_lineno":147,"ph":"X","cat":"FEE"}],"displayTimeUnit":"ns","viztracer_metadata":{"version":"0.9.5"}}'  # noqa: E501
 

--- a/tests/archived/_test_simulator.py
+++ b/tests/archived/_test_simulator.py
@@ -71,7 +71,7 @@ class SimInterface:
                 self.sim_process.stdout.close()
                 self.sim_process.stdin.close()
                 if self.sim_process.returncode != 0:
-                    raise Exception("error code {}".format(self.sim_process.returncode))
+                    raise Exception(f"error code {self.sim_process.returncode}")
             except subprocess.TimeoutExpired:
                 self.sim_process.terminate()
 

--- a/tests/archived/_test_simulator.py
+++ b/tests/archived/_test_simulator.py
@@ -2,13 +2,12 @@
 # For details: https://github.com/gaogaotiantian/viztracer/blob/master/NOTICE.txt
 
 import os
-import sys
 import subprocess
+import sys
 
-from .package_env import package_matrix
-from .util import get_json_file_path, adapt_json_file, generate_json
 from .base_tmpl import BaseTmpl
-
+from .package_env import package_matrix
+from .util import adapt_json_file, generate_json, get_json_file_path
 
 adapt_json_file("vdb_basic.json")
 vdb_basic = get_json_file_path("vdb_basic.json")

--- a/tests/base_tmpl.py
+++ b/tests/base_tmpl.py
@@ -9,7 +9,6 @@ import sys
 import time
 from unittest import TestCase
 
-
 logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s %(levelname)s: %(message)s"

--- a/tests/base_tmpl.py
+++ b/tests/base_tmpl.py
@@ -11,7 +11,7 @@ from unittest import TestCase
 
 logging.basicConfig(
     level=logging.INFO,
-    format="%(asctime)s %(levelname)s: %(message)s"
+    format="%(asctime)s %(levelname)s: %(message)s",
 )
 
 

--- a/tests/cmdline_tmpl.py
+++ b/tests/cmdline_tmpl.py
@@ -8,8 +8,8 @@ import shutil
 import subprocess
 import sys
 import time
-from .base_tmpl import BaseTmpl
 
+from .base_tmpl import BaseTmpl
 
 file_fib = """
 def fib(n):

--- a/tests/data/vdb_basic.py
+++ b/tests/data/vdb_basic.py
@@ -1,5 +1,6 @@
 # import wthell
-from viztracer import VizCounter, VizTracer, VizObject
+from viztracer import VizCounter, VizObject, VizTracer
+
 # from wthell import wth
 
 

--- a/tests/data/vdb_multithread.py
+++ b/tests/data/vdb_multithread.py
@@ -1,6 +1,7 @@
 import threading
-from viztracer import VizTracer, ignore_function
 import time
+
+from viztracer import VizTracer, ignore_function
 
 
 @ignore_function

--- a/tests/modules/issue58.py
+++ b/tests/modules/issue58.py
@@ -1,8 +1,8 @@
 # Licensed under the Apache License: http://www.apache.org/licenses/LICENSE-2.0
 # For details: https://github.com/gaogaotiantian/viztracer/blob/master/NOTICE.txt
 
-from multiprocessing import Pool
 import gc
+from multiprocessing import Pool
 
 
 def pool_worker(item):

--- a/tests/package_env.py
+++ b/tests/package_env.py
@@ -1,12 +1,12 @@
 # Licensed under the Apache License: http://www.apache.org/licenses/LICENSE-2.0
 # For details: https://github.com/gaogaotiantian/viztracer/blob/master/NOTICE.txt
 
-from contextlib import contextmanager
 import inspect
-from itertools import product
 import os
 import subprocess
 import sys
+from contextlib import contextmanager
+from itertools import product
 from unittest import SkipTest
 
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -221,14 +221,14 @@ class TestDecorator(BaseTmpl):
 
             def t1():
                 a = subprocess.run(
-                    ["ls result_my_function2*.json"], shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+                    ["ls result_my_function2*.json"], shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
                 )
                 self.assertEqual(a.returncode, 0)
             self.assertTrueTimeout(t1, timeout)
 
             def t2():
                 a = subprocess.run(
-                    ["rm result_my_function2*.json"], shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+                    ["rm result_my_function2*.json"], shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
                 )
                 self.assertEqual(a.returncode, 0)
             self.assertTrueTimeout(t2, timeout)
@@ -267,7 +267,7 @@ class TestForkSave(BaseTmpl):
             6: 25,
             7: 41,
             8: 67,
-            9: 109
+            9: 109,
         }
         pid = None
         for i in range(5, 10):

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -8,8 +8,10 @@ import subprocess
 import sys
 import tempfile
 import time
+
+from viztracer import VizTracer, get_tracer, ignore_function, trace_and_save
 from viztracer.tracer import _VizTracer
-from viztracer import VizTracer, ignore_function, trace_and_save, get_tracer
+
 from .base_tmpl import BaseTmpl
 
 

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -3,15 +3,15 @@
 
 import configparser
 import importlib.util
-from contextlib import contextmanager
 import os
+import re
 import signal
 import sys
-import re
+from contextlib import contextmanager
 from unittest.case import skipIf
+
 from .cmdline_tmpl import CmdlineTmpl
 from .package_env import package_matrix
-
 
 file_c_function = """
 lst = []

--- a/tests/test_codemonkey.py
+++ b/tests/test_codemonkey.py
@@ -3,7 +3,9 @@
 
 import ast
 import textwrap
-from viztracer.code_monkey import CodeMonkey, AstTransformer
+
+from viztracer.code_monkey import AstTransformer, CodeMonkey
+
 from .base_tmpl import BaseTmpl
 from .cmdline_tmpl import CmdlineTmpl
 

--- a/tests/test_codemonkey.py
+++ b/tests/test_codemonkey.py
@@ -24,7 +24,7 @@ class TestCodeMonkey(BaseTmpl):
                 a = 3 / 0
             except Exception as e:
                 raise
-            """
+            """,
         )
         monkey = CodeMonkey("test.py")
         monkey.add_instrument("log_exception", {})

--- a/tests/test_fastlog.py
+++ b/tests/test_fastlog.py
@@ -2,6 +2,7 @@
 # For details: https://github.com/gaogaotiantian/viztracer/blob/master/NOTICE.txt
 
 from viztracer import VizTracer
+
 from .base_tmpl import BaseTmpl
 
 

--- a/tests/test_flamegraph.py
+++ b/tests/test_flamegraph.py
@@ -2,8 +2,10 @@
 # For details: https://github.com/gaogaotiantian/viztracer/blob/master/NOTICE.txt
 
 import json
-from viztracer.flamegraph import FlameGraph
 import os
+
+from viztracer.flamegraph import FlameGraph
+
 from .base_tmpl import BaseTmpl
 
 

--- a/tests/test_flamegraph.py
+++ b/tests/test_flamegraph.py
@@ -22,7 +22,7 @@ class TestFlameGraph(BaseTmpl):
 
         # Test if FlameGraph can handle empty tree
         sample_data["traceEvents"].append(
-            {"ph": "M", "pid": 1, "tid": 1, "name": "thread_name", "args": {"name": "MainThread"}}
+            {"ph": "M", "pid": 1, "tid": 1, "name": "thread_name", "args": {"name": "MainThread"}},
         )
         fg = FlameGraph(sample_data)
         self.assertEqual(len(fg.trees), 6)

--- a/tests/test_functree.py
+++ b/tests/test_functree.py
@@ -3,9 +3,10 @@
 
 
 import json
-from viztracer.functree import FuncTree
-from .base_tmpl import BaseTmpl
 
+from viztracer.functree import FuncTree
+
+from .base_tmpl import BaseTmpl
 
 test_str = '{"traceEvents":[{"pid":7761,"tid":7761,"ts":23668655769.443,"dur":0.4,"name":"h (test.py:6)","caller_lineno":10,"ph":"X","cat":"FEE"},{"pid":7761,"tid":7761,"ts":23668655769.243,"dur":1.2,"name":"g (test.py:9)","caller_lineno":18,"ph":"X","cat":"FEE"},{"pid":7761,"tid":7761,"ts":23668655770.543,"dur":0.1,"name":"h (test.py:6)","caller_lineno":19,"ph":"X","cat":"FEE"},{"pid":7761,"tid":7761,"ts":23668655769.043,"dur":1.7,"name":"f (test.py:14)","caller_lineno":22,"ph":"X","cat":"FEE"},{"pid":7761,"tid":7761,"ts":23668655771.143,"dur":0.1,"name":"h (test.py:6)","caller_lineno":10,"ph":"X","cat":"FEE"},{"pid":7761,"tid":7761,"ts":23668655771.043,"dur":0.3,"name":"g (test.py:9)","caller_lineno":17,"ph":"X","cat":"FEE"},{"pid":7761,"tid":7761,"ts":23668655771.443,"dur":0.0,"name":"h (test.py:6)","caller_lineno":19,"ph":"X","cat":"FEE"},{"pid":7761,"tid":7761,"ts":23668655770.943,"dur":0.6,"name":"f (test.py:14)","caller_lineno":24,"ph":"X","cat":"FEE"},{"pid":7761,"tid":7761,"ts":23668655768.843,"dur":2.8,"name":"t (test.py:21)","caller_lineno":26,"ph":"X","cat":"FEE"},{"pid":7761,"tid":7761,"ts":23668655766.943,"dur":4.8,"name":"<module> (test.py:2)","caller_lineno":147,"ph":"X","cat":"FEE"},{"pid":7761,"tid":7761,"ts":23668655766.343,"dur":5.8,"name":"builtins.exec","caller_lineno":147,"ph":"X","cat":"FEE"}],"displayTimeUnit":"ns","viztracer_metadata":{"version":"0.9.5"}}'  # noqa: E501
 

--- a/tests/test_invalid.py
+++ b/tests/test_invalid.py
@@ -23,7 +23,7 @@ class TestInvalidArgs(BaseTmpl):
             "vdb": ["hello", 1, "True"],
             "min_duration": ["0.1.0", "12", "3us"],
             "ignore_frozen": ["hello", 1, "True"],
-            "log_async": ["hello", 1, "True"]
+            "log_async": ["hello", 1, "True"],
         }
         tracer = VizTracer(verbose=0)
         for args, vals in invalid_args.items():

--- a/tests/test_invalid.py
+++ b/tests/test_invalid.py
@@ -1,8 +1,9 @@
 # Licensed under the Apache License: http://www.apache.org/licenses/LICENSE-2.0
 # For details: https://github.com/gaogaotiantian/viztracer/blob/master/NOTICE.txt
 
-from viztracer.event_base import _EventBase
 from viztracer import VizTracer
+from viztracer.event_base import _EventBase
+
 from .base_tmpl import BaseTmpl
 
 

--- a/tests/test_jupyter.py
+++ b/tests/test_jupyter.py
@@ -3,6 +3,7 @@
 
 
 import os
+
 from .base_tmpl import BaseTmpl
 
 
@@ -10,7 +11,8 @@ class TestJupyter(BaseTmpl):
     def setUp(self):
         super().setUp()
         try:
-            from IPython.terminal.interactiveshell import TerminalInteractiveShell
+            from IPython.terminal.interactiveshell import \
+                TerminalInteractiveShell
             self.ip = TerminalInteractiveShell.instance()
         except ImportError:
             self.skipTest("No Jupyter, skip Jupyter test")

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -2,7 +2,9 @@
 # For details: https://github.com/gaogaotiantian/viztracer/blob/master/NOTICE.txt
 
 import logging
-from viztracer import VizTracer, VizLoggingHandler
+
+from viztracer import VizLoggingHandler, VizTracer
+
 from .base_tmpl import BaseTmpl
 
 

--- a/tests/test_logsparse.py
+++ b/tests/test_logsparse.py
@@ -1,10 +1,10 @@
 # Licensed under the Apache License: http://www.apache.org/licenses/LICENSE-2.0
 # For details: https://github.com/gaogaotiantian/viztracer/blob/master/NOTICE.txt
 
-from .cmdline_tmpl import CmdlineTmpl
 import multiprocessing
 import os
 
+from .cmdline_tmpl import CmdlineTmpl
 
 file_basic = """
 from viztracer import log_sparse

--- a/tests/test_multiprocess.py
+++ b/tests/test_multiprocess.py
@@ -1,15 +1,15 @@
 # Licensed under the Apache License: http://www.apache.org/licenses/LICENSE-2.0
 # For details: https://github.com/gaogaotiantian/viztracer/blob/master/NOTICE.txt
 
-import os
-import sys
 import multiprocessing
+import os
 import signal
+import sys
 import tempfile
 import unittest
 from unittest.case import skipIf
-from .cmdline_tmpl import CmdlineTmpl
 
+from .cmdline_tmpl import CmdlineTmpl
 
 file_grandparent = """
 import subprocess

--- a/tests/test_multithread.py
+++ b/tests/test_multithread.py
@@ -1,9 +1,11 @@
 # Licensed under the Apache License: http://www.apache.org/licenses/LICENSE-2.0
 # For details: https://github.com/gaogaotiantian/viztracer/blob/master/NOTICE.txt
 
-from viztracer import VizTracer, get_tracer
-import time
 import threading
+import time
+
+from viztracer import VizTracer, get_tracer
+
 from .base_tmpl import BaseTmpl
 from .cmdline_tmpl import CmdlineTmpl
 

--- a/tests/test_patch.py
+++ b/tests/test_patch.py
@@ -2,7 +2,6 @@
 # For details: https://github.com/gaogaotiantian/viztracer/blob/master/NOTICE.txt
 
 
-from .cmdline_tmpl import CmdlineTmpl
 import os
 import re
 import shutil
@@ -12,6 +11,7 @@ import tempfile
 import unittest
 from string import Template
 
+from .cmdline_tmpl import CmdlineTmpl
 
 file_spawn_tmpl = Template("""
 import multiprocessing

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -58,7 +58,7 @@ class BenchmarkTimer:
 
     def print_result(self):
         def time_str(baseline, experiment):
-            return "{:.9f}({:.2f})[{}]".format(experiment["dur"], experiment["dur"] / baseline["dur"], experiment["section"])
+            return f"{experiment['dur']:.9f}({experiment['dur'] / baseline['dur']:.2f})[{experiment['section']}]"
         for experiments in self.timer_experiments.values():
             logging.info(" ".join([time_str(self.timer_baseline, experiment) for experiment in experiments]))
 
@@ -199,7 +199,7 @@ class TestPerformance(BaseTmpl):
                 self.z = (x * x) / 2
 
             def __repr__(self):
-                return "<Point: x=%s, y=%s, z=%s>" % (self.x, self.y, self.z)
+                return f"<Point: x={self.x}, y={self.y}, z={self.z}>"
 
             def normalize(self):
                 x = self.x
@@ -262,9 +262,9 @@ class TestFilterPerformance(BaseTmpl):
         tracer.cleanup()
 
         logging.info("Filter performance:")
-        logging.info("Baseline:        {:.9f}(1)".format(baseline))
-        logging.info("Include:         {:.9f}({:.2f})".format(include_files, include_files / baseline))
-        logging.info("Max stack depth: {:.9f}({:.2f})".format(max_stack_depth, max_stack_depth / baseline))
+        logging.info(f"Baseline:        {baseline:.9f}(1)")
+        logging.info(f"Include:         {include_files:.9f}({include_files / baseline:.2f})")
+        logging.info(f"Max stack depth: {max_stack_depth:.9f}({max_stack_depth / baseline:.2f})")
 
     def test_hanoi(self):
         def hanoi():

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -190,7 +190,7 @@ class TestPerformance(BaseTmpl):
     def test_float(self):
         from math import cos, sin, sqrt
 
-        class Point(object):
+        class Point():
             __slots__ = ('x', 'y', 'z')
 
             def __init__(self, i):

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -9,7 +9,9 @@ import os
 import random
 import tempfile
 import time
+
 from viztracer import VizTracer
+
 from .base_tmpl import BaseTmpl
 
 
@@ -186,7 +188,7 @@ class TestPerformance(BaseTmpl):
         self.do_one_function(list_operation)
 
     def test_float(self):
-        from math import sin, cos, sqrt
+        from math import cos, sin, sqrt
 
         class Point(object):
             __slots__ = ('x', 'y', 'z')

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -47,7 +47,7 @@ class BenchmarkTimer:
             end_time = time.perf_counter()
             data = {
                 "dur": end_time - start_time,
-                "section": section
+                "section": section,
             }
             if baseline:
                 self.timer_baseline = data

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -209,7 +209,7 @@ class TestIssue119(CmdlineTmpl):
                     self.template(
                         ["viztracer", "-o", "result.json", "cmdline_test.py", script_dir],
                         script=issue119_code,
-                        expected_output_file=filepath
+                        expected_output_file=filepath,
                     )
                 finally:
                     os.chdir(cwd)
@@ -237,7 +237,7 @@ class TestIssue121(CmdlineTmpl):
         self.template(
             ["viztracer", "cmdline_test.py", "--log_exit"],
             script=issue121_code,
-            check_func=check_func
+            check_func=check_func,
         )
 
 

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -12,8 +12,8 @@ import unittest
 import viztracer
 from viztracer import VizTracer, ignore_function
 
-from .cmdline_tmpl import CmdlineTmpl
 from .base_tmpl import BaseTmpl
+from .cmdline_tmpl import CmdlineTmpl
 
 
 class TestIssue1(BaseTmpl):

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -2,19 +2,21 @@
 # For details: https://github.com/gaogaotiantian/viztracer/blob/master/NOTICE.txt
 
 
-from viztracer import VizTracer
-from viztracer.attach_process.add_code_to_python_process import run_python_code  # type: ignore
-from viztracer.util import pid_exists
 import base64
 import json
 import os
 import re
 import signal
+import subprocess
 import sys
+import textwrap
 import time
 import unittest
-import textwrap
-import subprocess
+
+from viztracer import VizTracer
+from viztracer.attach_process.add_code_to_python_process import \
+    run_python_code  # type: ignore
+from viztracer.util import pid_exists
 
 from .cmdline_tmpl import CmdlineTmpl
 from .util import cmd_with_coverage

--- a/tests/test_report_builder.py
+++ b/tests/test_report_builder.py
@@ -6,8 +6,10 @@ import io
 import json
 import os
 import tempfile
+
 import viztracer
 from viztracer.report_builder import ReportBuilder
+
 from .base_tmpl import BaseTmpl
 
 

--- a/tests/test_tracer.py
+++ b/tests/test_tracer.py
@@ -4,8 +4,10 @@
 import io
 import os
 import time
-from viztracer.tracer import _VizTracer
+
 from viztracer import VizTracer
+from viztracer.tracer import _VizTracer
+
 from .base_tmpl import BaseTmpl
 
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -4,7 +4,9 @@
 import os
 import sys
 import unittest
+
 import viztracer.util
+
 from .base_tmpl import BaseTmpl
 
 

--- a/tests/test_vcompressor.py
+++ b/tests/test_vcompressor.py
@@ -26,12 +26,12 @@ class TestVCompressor(CmdlineTmpl):
             dup_json_path = os.path.join(tmpdir, "result.json")
             self.template(
                 ["viztracer", "-o", cvf_path, "--compress", get_tests_data_file_path("multithread.json")],
-                expected_output_file=cvf_path, cleanup=False
+                expected_output_file=cvf_path, cleanup=False,
             )
 
             self.template(
                 ["viztracer", "-o", dup_json_path, "--decompress", cvf_path],
-                expected_output_file=dup_json_path
+                expected_output_file=dup_json_path,
             )
 
     def test_compress_invalid(self):
@@ -40,13 +40,13 @@ class TestVCompressor(CmdlineTmpl):
             not_exist_path = os.path.join(tmpdir, "do_not_exist.json")
             result = self.template(
                 ["viztracer", "-o", cvf_path, "--compress", not_exist_path],
-                expected_output_file=None, success=False
+                expected_output_file=None, success=False,
             )
             self.assertIn("Unable to find file", result.stdout.decode("utf8"))
 
             result = self.template(
                 ["viztracer", "-o", cvf_path, "--compress", get_tests_data_file_path("fib.py")],
-                expected_output_file=None, success=False
+                expected_output_file=None, success=False,
             )
             self.assertIn("Only support compressing json report", result.stdout.decode("utf8"))
 
@@ -54,13 +54,13 @@ class TestVCompressor(CmdlineTmpl):
         default_compress_output = "result.cvf"
         self.template(
             ["viztracer", "--compress", get_tests_data_file_path("multithread.json")],
-            expected_output_file=default_compress_output, cleanup=False
+            expected_output_file=default_compress_output, cleanup=False,
         )
         self.assertTrue(os.path.exists(default_compress_output))
 
         self.template(
             ["viztracer", "-o", "result.json", "--decompress", default_compress_output],
-            expected_output_file="result.json"
+            expected_output_file="result.json",
         )
         self.cleanup(output_file=default_compress_output)
 
@@ -70,7 +70,7 @@ class TestVCompressor(CmdlineTmpl):
             dup_json_path = os.path.join(tmpdir, "result.json")
             result = self.template(
                 ["viztracer", "-o", dup_json_path, "--decompress", not_exist_path],
-                expected_output_file=dup_json_path, success=False
+                expected_output_file=dup_json_path, success=False,
             )
             self.assertIn("Unable to find file", result.stdout.decode("utf8"))
 
@@ -80,12 +80,12 @@ class TestVCompressor(CmdlineTmpl):
             default_decompress_output = "result.json"
             self.template(
                 ["viztracer", "-o", cvf_path, "--compress", get_tests_data_file_path("multithread.json")],
-                expected_output_file=cvf_path, cleanup=False
+                expected_output_file=cvf_path, cleanup=False,
             )
 
             self.template(
                 ["viztracer", "--decompress", cvf_path],
-                expected_output_file=default_decompress_output, cleanup=False
+                expected_output_file=default_decompress_output, cleanup=False,
             )
             self.assertTrue(os.path.exists(default_decompress_output))
             self.cleanup(output_file=default_decompress_output)
@@ -167,7 +167,7 @@ class TestVCompressorPerformance(CmdlineTmpl):
         original_size: int,
         vcompress_result: BenchmarkResult,
         other_results: List[Tuple[str, BenchmarkResult]],  # [(compressor_name, BenchmarkResult)]
-        subtest_idx: Optional[int] = None
+        subtest_idx: Optional[int] = None,
     ):
         if subtest_idx is None:
             logging.info(f"On file \"{filename}\":")
@@ -200,14 +200,14 @@ class TestVCompressorPerformance(CmdlineTmpl):
             logging.info("      {}{:9.3f}s({:.3f})".format(
                 name + ":" + " " * max(15 - len(name), 0),
                 result.elapsed_time,
-                result.elapsed_time / vcompress_result.elapsed_time
+                result.elapsed_time / vcompress_result.elapsed_time,
             ))
 
     @_benchmark
     def _benchmark_vcompressor(self, uncompressed_file_path: str, compressed_file_path: str) -> None:
         self.template(
             ["viztracer", "-o", compressed_file_path, "--compress", uncompressed_file_path],
-            expected_output_file=compressed_file_path, script=None, cleanup=False
+            expected_output_file=compressed_file_path, script=None, cleanup=False,
         )
 
     @_benchmark
@@ -228,7 +228,7 @@ class TestVCompressorPerformance(CmdlineTmpl):
         tmp_compress_file = uncompressed_file_path + ".tmp"
         self.template(
             ["viztracer", "-o", tmp_compress_file, "--compress", uncompressed_file_path],
-            expected_output_file=tmp_compress_file, script=None, cleanup=False
+            expected_output_file=tmp_compress_file, script=None, cleanup=False,
         )
         with open(tmp_compress_file, "rb") as tmp_file:
             with lzma.open(compressed_file_path, "wb", preset=lzma.PRESET_DEFAULT) as compressed_file:
@@ -239,7 +239,7 @@ class TestVCompressorPerformance(CmdlineTmpl):
         tmp_compress_file = uncompressed_file_path + ".tmp"
         self.template(
             ["viztracer", "-o", tmp_compress_file, "--compress", uncompressed_file_path],
-            expected_output_file=tmp_compress_file, script=None, cleanup=False
+            expected_output_file=tmp_compress_file, script=None, cleanup=False,
         )
         with open(tmp_compress_file, "rb") as tmp_file:
             compressed_data = zlib.compress(tmp_file.read())
@@ -269,7 +269,7 @@ class TestVCompressorPerformance(CmdlineTmpl):
             run_script = test_large_fib % (origin_json_path.replace("\\", "/"))
             self.template(
                 ["python", "cmdline_test.py"], script=run_script, cleanup=False,
-                expected_output_file=origin_json_path
+                expected_output_file=origin_json_path,
             )
             original_size = os.path.getsize(origin_json_path)
             other_results = [
@@ -323,7 +323,7 @@ class VCompressorCompare(unittest.TestCase):
                          f"list length not equal, first is {len(first)} \n second is {len(second)}")
         first.sort(key=lambda i: (i["pid"], i["tid"]))
         second.sort(key=lambda i: (i["pid"], i["tid"]))
-        for i in range(len(first)):
+        for _ in range(len(first)):
             self.assertEqual(first, second,
                              f"{first} and {second} not equal")
 
@@ -462,11 +462,11 @@ class TestVCompressorCorrectness(CmdlineTmpl, VCompressorCompare):
             dup_json_path = os.path.join(tmpdir, "result.json")
             self.template(
                 ["viztracer", "-o", cvf_path, "--compress", get_tests_data_file_path(test_file)],
-                expected_output_file=cvf_path, cleanup=False
+                expected_output_file=cvf_path, cleanup=False,
             )
             self.template(
                 ["viztracer", "-o", dup_json_path, "--decompress", cvf_path],
-                expected_output_file=dup_json_path, cleanup=False
+                expected_output_file=dup_json_path, cleanup=False,
             )
 
             with open(get_tests_data_file_path(test_file), "r") as f:
@@ -483,15 +483,15 @@ class TestVCompressorCorrectness(CmdlineTmpl, VCompressorCompare):
             run_script = run_script % (origin_json_path.replace("\\", "/"))
             self.template(
                 ["python", "cmdline_test.py"], script=run_script, cleanup=False,
-                expected_output_file=origin_json_path
+                expected_output_file=origin_json_path,
             )
             self.template(
                 ["viztracer", "-o", cvf_path, "--compress", origin_json_path],
-                expected_output_file=cvf_path, cleanup=False
+                expected_output_file=cvf_path, cleanup=False,
             )
             self.template(
                 ["viztracer", "-o", dup_json_path, "--decompress", cvf_path],
-                expected_output_file=dup_json_path, cleanup=False
+                expected_output_file=dup_json_path, cleanup=False,
             )
             with open(origin_json_path, "r") as f:
                 origin_json_data = json.load(f)

--- a/tests/test_vcompressor.py
+++ b/tests/test_vcompressor.py
@@ -2,13 +2,13 @@
 # For details: https://github.com/gaogaotiantian/viztracer/blob/master/NOTICE.txt
 
 
+import json
 import logging
 import lzma
-import zlib
 import os
 import tempfile
-import json
 import unittest
+import zlib
 from collections import namedtuple
 from functools import wraps
 from shutil import copyfileobj

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -2,22 +2,24 @@
 # For details: https://github.com/gaogaotiantian/viztracer/blob/master/NOTICE.txt
 
 
-import shutil
-from .cmdline_tmpl import CmdlineTmpl
 import json
 import multiprocessing
 import os
 import re
+import shutil
 import signal
 import socket
 import subprocess
 import sys
-import time
 import tempfile
+import time
 import unittest.mock
 import urllib.request
-from viztracer.viewer import viewer_main
 import webbrowser
+
+from viztracer.viewer import viewer_main
+
+from .cmdline_tmpl import CmdlineTmpl
 
 
 class Viewer(unittest.TestCase):

--- a/tests/test_vizcounter.py
+++ b/tests/test_vizcounter.py
@@ -1,7 +1,8 @@
 # Licensed under the Apache License: http://www.apache.org/licenses/LICENSE-2.0
 # For details: https://github.com/gaogaotiantian/viztracer/blob/master/NOTICE.txt
 
-from viztracer import VizTracer, VizCounter
+from viztracer import VizCounter, VizTracer
+
 from .base_tmpl import BaseTmpl
 
 

--- a/tests/test_vizevent.py
+++ b/tests/test_vizevent.py
@@ -2,6 +2,7 @@
 # For details: https://github.com/gaogaotiantian/viztracer/blob/master/NOTICE.txt
 
 from viztracer import VizTracer
+
 from .base_tmpl import BaseTmpl
 
 

--- a/tests/test_vizobject.py
+++ b/tests/test_vizobject.py
@@ -1,8 +1,8 @@
 # Licensed under the Apache License: http://www.apache.org/licenses/LICENSE-2.0
 # For details: https://github.com/gaogaotiantian/viztracer/blob/master/NOTICE.txt
 
-from viztracer import VizTracer
-from viztracer import VizObject
+from viztracer import VizObject, VizTracer
+
 from .base_tmpl import BaseTmpl
 
 

--- a/tests/test_vizplugin.py
+++ b/tests/test_vizplugin.py
@@ -2,11 +2,13 @@
 # For details: https://github.com/gaogaotiantian/viztracer/blob/master/NOTICE.txt
 
 
-from contextlib import redirect_stdout
 import io
-from .cmdline_tmpl import CmdlineTmpl
+from contextlib import redirect_stdout
+
 from viztracer import VizTracer
 from viztracer.vizplugin import VizPluginBase, VizPluginError
+
+from .cmdline_tmpl import CmdlineTmpl
 
 
 class MyPlugin(VizPluginBase):

--- a/tests/test_vizplugin.py
+++ b/tests/test_vizplugin.py
@@ -29,12 +29,11 @@ class MyPlugin(VizPluginBase):
         if m_type == "event" and payload["when"] == "pre-save":
             return {
                 "action": "handle_data",
-                "handler": f
+                "handler": f,
             }
 
-        if m_type == "command":
-            if payload["cmd_type"] == "terminate":
-                return {"success": self.terminate_well}
+        if m_type == "command" and payload["cmd_type"] == "terminate":
+            return {"success": self.terminate_well}
         return {}
 
 

--- a/tests/util.py
+++ b/tests/util.py
@@ -30,7 +30,7 @@ def adapt_json_file(filename):
                 try:
                     m = name_regex.match(event["name"])
                     if m and py_filename in event["name"]:
-                        event["name"] = "{} ({}:{})".format(m.group(1), py_path, m.group(3))
+                        event["name"] = f"{m.group(1)} ({py_path}:{m.group(3)})"
                 except ValueError:
                     pass
 

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,10 +1,10 @@
 # Licensed under the Apache License: http://www.apache.org/licenses/LICENSE-2.0
 # For details: https://github.com/gaogaotiantian/viztracer/blob/master/NOTICE.txt
 
-import os
 import json
-import subprocess
+import os
 import re
+import subprocess
 
 
 def generate_json(filename):


### PR DESCRIPTION
cleaned up imports
replaced format strings with f-strings
removed trailing newlines
replaced exit() with sys.exit()
py3 doesn't need inheritance from object, fixed a few of those
replaced a deprecated call to warn() with warning()
fixed a bunch of flake8 warnings (indicated in that commit)

pytest run, I'm actually getting failures, but the same ones that failed before I started these changes, so considering it ok for now.