### PR TITLE
Fix subprocess argument building issue

### DIFF
--- a/src/viztracer/patch.py
+++ b/src/viztracer/patch.py
@@ -50,15 +50,17 @@ def patch_subprocess(viz_args: list[str]) -> None:
                         py_args.append(f"-{cm_py_args}")
                     mode = [f"-{cm}"]
                     # -m mod | -mmod
-                    script = cm_arg or next(args_iter, None)
+                    mode.append(cm_arg or next(args_iter, None))
                 break
 
             # -pyopts
             py_args.append(arg)
 
-        if script is None:
-            return None
-        return [sys.executable, *py_args, "-m", "viztracer", "--quiet", *viz_args, *mode, script, *args_iter]
+        if script:
+            return [sys.executable, *py_args, "-m", "viztracer", "--quiet", *viz_args, "--", script, *args_iter]
+        elif mode and mode[-1] is not None:
+            return [sys.executable, *py_args, "-m", "viztracer", "--quiet", *viz_args, *mode, "--", *args_iter]
+        return None
 
     @functools.wraps(subprocess.Popen.__init__)
     def subprocess_init(self: subprocess.Popen[Any], args: Union[str, Sequence[Any], Any], **kwargs: Any) -> None:

--- a/tests/test_patch.py
+++ b/tests/test_patch.py
@@ -81,6 +81,8 @@ print(subprocess.check_output(["python", "-c", r"import sys; sys.stdout.buffer.w
 print(subprocess.check_output(["python", "-", "foo"], input=b"import sys; print(sys.argv)"))
 print(subprocess.check_output(["python"], input=b"import sys; print(sys.argv)"))
 print(subprocess.check_output(["python", "-im", "check_output_echo", "asdf"], input=b"import sys; print(sys.argv)"))
+print(subprocess.check_output(["python", "check_output_echo.py", "test.py", "--output_dir", "test", "--other", "abc"]))
+print(subprocess.check_output(["python", "-m", "check_output_echo", "test.py", "--output_dir", "test", "--other", "abc"]))
 
 os.remove("check_output_echo.py")
 """


### PR DESCRIPTION
Explicitly add `--` to avoid the program arguments accidentally inhaled by viztracer