### PR TITLE
check pid exists when waiting for child

### DIFF
--- a/src/viztracer/main.py
+++ b/src/viztracer/main.py
@@ -16,6 +16,7 @@ import tempfile
 import threading
 import time
 import types
+import re
 from typing import Any, Dict, List, Optional, Tuple
 
 from viztracer.vcompressor import VCompressor
@@ -592,12 +593,14 @@ class VizUI:
                 same_line_print("Wait for child processes to finish, Ctrl+C to skip")
                 while True:
                     remain_viztmp = [f for f in os.listdir(self.multiprocess_output_dir) if f.endswith(".viztmp")]
-                    if not remain_viztmp:
-                        break
-                    remain_children = list(int(f[7:-12]) for f in remain_viztmp)
-                    for pid in remain_children:
-                        if pid_exists(pid):
-                            break
+                    for viztmp_file in remain_viztmp:
+                        match = re.search(r'result_(\d+).json.viztmp', viztmp_file)
+                        if match:
+                            pid = int(match.group(1))
+                            if pid_exists(pid):
+                                break
+                        else:   # pragma: no cover
+                            color_print("WARNING", f"Can't parse {viztmp_file}, skip")
                     else:
                         break
                     time.sleep(0.5)

--- a/src/viztracer/main.py
+++ b/src/viztracer/main.py
@@ -600,7 +600,7 @@ class VizUI:
                             if pid_exists(pid):
                                 break
                         else:   # pragma: no cover
-                            color_print("WARNING", f"Can't parse {viztmp_file}, skip")
+                            color_print("WARNING", f"Unknown viztmp file {viztmp_file}")
                     else:
                         break
                     time.sleep(0.5)

--- a/src/viztracer/main.py
+++ b/src/viztracer/main.py
@@ -590,7 +590,16 @@ class VizUI:
         try:
             if any((f.endswith(".viztmp") for f in os.listdir(self.multiprocess_output_dir))):
                 same_line_print("Wait for child processes to finish, Ctrl+C to skip")
-                while any((f.endswith(".viztmp") for f in os.listdir(self.multiprocess_output_dir))):
+                while True:
+                    remain_viztmp = [f for f in os.listdir(self.multiprocess_output_dir) if f.endswith(".viztmp")]
+                    if not remain_viztmp:
+                        break
+                    remain_children = list(int(f[7:-12]) for f in remain_viztmp)
+                    for pid in remain_children:
+                        if pid_exists(pid):
+                            break
+                    else:
+                        break
                     time.sleep(0.5)
         except KeyboardInterrupt:
             pass

--- a/src/viztracer/util.py
+++ b/src/viztracer/util.py
@@ -118,25 +118,8 @@ def pid_exists(pid):
         # On Windows, 0 is an idle process buw we don't need to
         # check it here
         raise ValueError('invalid PID 0')
-    # UNIX
-    if sys.platform != "win32":
-        try:
-            os.kill(pid, 0)
-        except OSError as err:
-            if err.errno == errno.ESRCH:
-                # ESRCH == No such process
-                return False
-            elif err.errno == errno.EPERM:
-                # EPERM clearly means there's a process to deny access to
-                return True
-            else:  # pragma: no cover
-                # According to "man 2 kill" possible error values are
-                # (EINVAL, EPERM, ESRCH)
-                raise
-        else:
-            return True
     # Windows
-    else:
+    if sys.platform == "win32":
         kernel32 = ctypes.windll.kernel32
 
         process = kernel32.OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid)
@@ -170,3 +153,20 @@ def pid_exists(pid):
                 # Usually it's impossible to run here in viztracer.
                 return True
         return False    # pragma: no cover
+    # UNIX
+    else:
+        try:
+            os.kill(pid, 0)
+        except OSError as err:
+            if err.errno == errno.ESRCH:
+                # ESRCH == No such process
+                return False
+            elif err.errno == errno.EPERM:
+                # EPERM clearly means there's a process to deny access to
+                return True
+            else:  # pragma: no cover
+                # According to "man 2 kill" possible error values are
+                # (EINVAL, EPERM, ESRCH)
+                raise
+        else:
+            return True

--- a/src/viztracer/util.py
+++ b/src/viztracer/util.py
@@ -118,8 +118,8 @@ def pid_exists(pid):
         # On Windows, 0 is an idle process buw we don't need to
         # check it here
         raise ValueError('invalid PID 0')
-    # Windows
     if sys.platform == "win32":
+        # Windows
         kernel32 = ctypes.windll.kernel32
 
         process = kernel32.OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid)
@@ -153,8 +153,8 @@ def pid_exists(pid):
                 # Usually it's impossible to run here in viztracer.
                 return True
         return False    # pragma: no cover
-    # UNIX
     else:
+        # UNIX
         try:
             os.kill(pid, 0)
         except OSError as err:

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -398,7 +398,7 @@ if __name__ == '__main__':
     p.start()
     # The main process will join the child in multiprocessing.process._children.
     # This is a hack to make sure the main process won't join the child process,
-    # so we can test the wait_children_finish function
+    # so we can test the VizUI.wait_children_finish function
     multiprocessing.process._children = set()
     time.sleep(1)
 """
@@ -418,7 +418,7 @@ if __name__ == '__main__':
     p.start()
     # The main process will join the child in multiprocessing.process._children.
     # This is a hack to make sure the main process won't join the child process,
-    # so we can test the wait_children_finish function
+    # so we can test the VizUI.wait_children_finish function
     multiprocessing.process._children = set()
     time.sleep(1)
 """

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -396,6 +396,9 @@ def target():
 if __name__ == '__main__':
     p = multiprocessing.Process(target=target)
     p.start()
+    # The main process will join the child in multiprocessing.process._children.
+    # This is a hack to make sure the main process won't join the child process,
+    # so we can test the wait_children_finish function
     multiprocessing.process._children = set()
     time.sleep(1)
 """
@@ -413,6 +416,9 @@ def target():
 if __name__ == '__main__':
     p = multiprocessing.Process(target=target)
     p.start()
+    # The main process will join the child in multiprocessing.process._children.
+    # This is a hack to make sure the main process won't join the child process,
+    # so we can test the wait_children_finish function
     multiprocessing.process._children = set()
     time.sleep(1)
 """
@@ -420,11 +426,11 @@ if __name__ == '__main__':
 
 class TestWaitForChild(CmdlineTmpl):
     def test_child_process_exits_normally(self):
-        self.template(["viztracer", "-o", "result.json", "--dump_raw", "cmdline_test.py"],
+        self.template(["viztracer", "-o", "result.json", "cmdline_test.py"],
                       expected_output_file="result.json", expected_stdout=r"Wait",
                       script=wait_for_child)
 
     def test_child_process_exits_abnormally(self):
-        self.template(["viztracer", "-o", "result.json", "--dump_raw", "cmdline_test.py"],
+        self.template(["viztracer", "-o", "result.json", "cmdline_test.py"],
                       expected_output_file="result.json", expected_stdout=r"Wait",
                       script=wait_for_terminated_child)


### PR DESCRIPTION
Added child check when waiting for children to finish, in case that child failed to delete viztmp file. The current `pid_exists` has a issue that if a process return 259 (STILL_ACTIVE) as exit code (which is a really rare case that is nearly impossible I guess).