### PR TITLE
make subprocess generate viztmp file

### DIFF
--- a/src/viztracer/main.py
+++ b/src/viztracer/main.py
@@ -330,6 +330,7 @@ class VizUI:
         signal.signal(signal.SIGTERM, term_handler)
 
         if options.subprocess_child:
+            tracer.label_file_to_write()
             multiprocessing.util.Finalize(tracer, tracer.exit_routine, exitpriority=-1)
         else:
             multiprocessing.util.Finalize(self, self.exit_routine, exitpriority=-1)


### PR DESCRIPTION
Currently, subprocess will not generate a viztmp file. So it's possible that the result.json misses some process data of subprocess.