### PR TITLE
fix: delete sim_main in `__init__` all

### DIFF
--- a/src/viztracer/__init__.py
+++ b/src/viztracer/__init__.py
@@ -16,7 +16,6 @@ from .viztracer import VizTracer, get_tracer
 __all__ = [
     "__version__",
     "main",
-    "sim_main",
     "viewer_main",
     "VizTracer",
     "ignore_function",

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -380,7 +380,8 @@ class TestCommandLineBasic(CmdlineTmpl):
         self.template(["viztracer", "-m", "numbers"])
 
     def test_import_star(self):
-        self.template(["python", "-c", "from viztracer import *"], script=None, expected_output_file=None)
+        script = "from viztracer import *"
+        self.template(["python", "cmdline_test.py"], script=script, expected_output_file=None)
 
     def test_log_gc(self):
         self.template(["viztracer", "--log_gc", "cmdline_test.py"], script=file_gc)

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -379,6 +379,9 @@ class TestCommandLineBasic(CmdlineTmpl):
     def test_module(self):
         self.template(["viztracer", "-m", "numbers"])
 
+    def test_import_star(self):
+        self.template(["python", "-c", "from viztracer import *"], expected_output_file=None)
+
     def test_log_gc(self):
         self.template(["viztracer", "--log_gc", "cmdline_test.py"], script=file_gc)
 

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -380,7 +380,7 @@ class TestCommandLineBasic(CmdlineTmpl):
         self.template(["viztracer", "-m", "numbers"])
 
     def test_import_star(self):
-        self.template(["python", "-c", "from viztracer import *"], expected_output_file=None)
+        self.template(["python", "-c", "from viztracer import *"], script=None, expected_output_file=None)
 
     def test_log_gc(self):
         self.template(["viztracer", "--log_gc", "cmdline_test.py"], script=file_gc)


### PR DESCRIPTION
caused it never use since sim_main had been deteled