### PR TITLE
Always use quotes around file paths in viewer_main function

### DIFF
--- a/src/viztracer/report_builder.py
+++ b/src/viztracer/report_builder.py
@@ -215,10 +215,12 @@ class ReportBuilder:
                 elif msg_type == "view_command":
                     report_abspath = os.path.abspath(msg_args["output_file"])
                     print("Use the following command to open the report:")
-                    if " " in report_abspath:
-                        color_print("OKGREEN", f"vizviewer \"{report_abspath}\"")
-                    else:
-                        color_print("OKGREEN", f"vizviewer {report_abspath}")
+                    # if " " in report_abspath:
+                    #     color_print("OKGREEN", f"vizviewer \"{report_abspath}\"")
+                    # else:
+                    #     color_print("OKGREEN", f"vizviewer {report_abspath}")
+
+                    color_print("OKGREEN", f"vizviewer \"{report_abspath}\"")
                 elif msg_type == "invalid_json":
                     print("")
                     color_print("WARNING", "Found and ignored invalid json file, you may lost some process data.")


### PR DESCRIPTION
Regardless of whether the absolute path contains spaces, it should always be used with quotes. This ensures consistent behavior across different environments and avoids potential issues with path parsing in shells and command line interfaces.

- Updated viewer_main function to always wrap the file path in quotes.
- This change improves compatibility and prevents errors related to space and special characters in file paths.