### PR TITLE
Remove extreme tests in vcompressor test

### DIFF
--- a/tests/test_vcompressor.py
+++ b/tests/test_vcompressor.py
@@ -344,13 +344,13 @@ tracer.start()
 class MyThreadSparse(threading.Thread):
     def run(self):
         counter = VizCounter(tracer, 'thread counter ' + str(self.ident))
-        counter.a = sys.maxsize - 1
+        counter.a = -1
         time.sleep(0.01)
-        counter.a = sys.maxsize * 2
+        counter.a = counter.a * 2
         time.sleep(0.01)
-        counter.a = -sys.maxsize + 2
+        counter.a = 2
         time.sleep(0.01)
-        counter.a = -sys.maxsize * 2
+        counter.a = counter.a * 2
 
 main_counter = VizCounter(tracer, 'main counter')
 thread1 = MyThreadSparse()
@@ -431,8 +431,8 @@ threads = [thread1, thread2]
 for thread in threads:
     thread.join()
 
-main_viz_object.arg1 = {100: "string1"}
-main_viz_object.arg2 = {100: "string1", -100: "string2"}
+main_viz_object.arg1 = {"100": "string1"}
+main_viz_object.arg2 = {"100": "string1", "-100": "string2"}
 
 tracer.stop()
 tracer.save(output_file='%s')


### PR DESCRIPTION
There are a few tests for vcompressor that test against some extreme cases, which is not fully compatible with `orjson`. The feature is not super popular so let's just dial it down a bit to make `orjson` happy.