### PR TITLE
Add special python args to subprocess patch

### DIFF
--- a/src/viztracer/patch.py
+++ b/src/viztracer/patch.py
@@ -55,6 +55,8 @@ def patch_subprocess(viz_args: list[str]) -> None:
 
             # -pyopts
             py_args.append(arg)
+            if arg in ("-X", "-W", "--check-hash-based-pycs"):
+                py_args.append(next(args_iter, None))
 
         if script:
             return [sys.executable, *py_args, "-m", "viztracer", "--quiet", *viz_args, "--", script, *args_iter]


### PR DESCRIPTION
Awesome project! I was recently adapting the patch utilities for subprocesses for a personal project and noticed that in some particular cases (i.e. when tracing `tox`) the patches don't work. The issue was resolved when I added the following python commands that take parameters (`-X`, `-W` and `--check-hash-based-pycs`) as special cases - otherwise their argument would be parsed as "script" parameter.

**Example**  
`python3 -X dev -m pytest` would be split to `python3 -X (patch-script) dev -m pytest` instead of the correct `python3 -X dev (patch-script) -m pytest`.