### PR TITLE
Fix tests runs in virtual environments on Windows

### DIFF
--- a/tests/cmdline_tmpl.py
+++ b/tests/cmdline_tmpl.py
@@ -57,6 +57,7 @@ class CmdlineTmpl(BaseTmpl):
                  check_func=None,
                  concurrency=None,
                  send_sig=None):
+        assert "python" not in cmd_list, "Do not use unqualified 'python' to launch intrepreter. Passing sys.executable is the recommended way."
         if os.getenv("COVERAGE_RUN"):
             if "viztracer" in cmd_list:
                 idx = cmd_list.index("viztracer")
@@ -71,11 +72,8 @@ class CmdlineTmpl(BaseTmpl):
                 idx = cmd_list.index("vizviewer")
                 cmd_list = ["coverage", "run", "--source", "viztracer", "--parallel-mode", "-m"] + ["viztracer.viewer"] \
                     + cmd_list[idx + 1:]
-            elif "python" in cmd_list or sys.executable in cmd_list:
-                if "python" in cmd_list:
-                    idx = cmd_list.index("python")
-                else:
-                    idx = cmd_list.index(sys.executable)
+            elif sys.executable in cmd_list:
+                idx = cmd_list.index(sys.executable)
                 cmd_list = ["coverage", "run", "--source", "viztracer", "--parallel-mode"] \
                     + cmd_list[idx + 1:]
 

--- a/tests/cmdline_tmpl.py
+++ b/tests/cmdline_tmpl.py
@@ -71,8 +71,11 @@ class CmdlineTmpl(BaseTmpl):
                 idx = cmd_list.index("vizviewer")
                 cmd_list = ["coverage", "run", "--source", "viztracer", "--parallel-mode", "-m"] + ["viztracer.viewer"] \
                     + cmd_list[idx + 1:]
-            elif "python" in cmd_list:
-                idx = cmd_list.index("python")
+            elif "python" in cmd_list or sys.executable in cmd_list:
+                if "python" in cmd_list:
+                    idx = cmd_list.index("python")
+                else:
+                    idx = cmd_list.index(sys.executable)
                 cmd_list = ["coverage", "run", "--source", "viztracer", "--parallel-mode"] \
                     + cmd_list[idx + 1:]
 

--- a/tests/cmdline_tmpl.py
+++ b/tests/cmdline_tmpl.py
@@ -57,7 +57,8 @@ class CmdlineTmpl(BaseTmpl):
                  check_func=None,
                  concurrency=None,
                  send_sig=None):
-        assert "python" not in cmd_list, "Do not use unqualified 'python' to launch intrepreter. Passing sys.executable is the recommended way."
+        assert "python" not in cmd_list, \
+            "Do not use unqualified 'python' to launch intrepreter. Passing sys.executable is the recommended way."
         if os.getenv("COVERAGE_RUN"):
             if "viztracer" in cmd_list:
                 idx = cmd_list.index("viztracer")

--- a/tests/modules/issue160.py
+++ b/tests/modules/issue160.py
@@ -1,3 +1,4 @@
 import subprocess
+import sys
 
-subprocess.run(["python", "-u", "-c", "lst=[]; lst.append(1)"])
+subprocess.run([sys.executable, "-u", "-c", "lst=[]; lst.append(1)"])

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -215,7 +215,7 @@ print(os.getpid())
 
 class TestCommandLineBasic(CmdlineTmpl):
     def test_no_file(self):
-        result = self.template(["python", "-m", "viztracer"], expected_output_file=None)
+        result = self.template([sys.executable, "-m", "viztracer"], expected_output_file=None)
         result_stdout = result.stdout.decode("utf8")
         self.assertIn("help", result_stdout)
         #  Check for a few more arguments to ensure we hit the intended argumentParser
@@ -227,15 +227,15 @@ class TestCommandLineBasic(CmdlineTmpl):
 
     def test_help(self):
         """Test that all three options print the same help page"""
-        result = self.template(["python", "-m", "viztracer"], expected_output_file=None)
-        result_h = self.template(["python", "-m", "viztracer", "-h"], expected_output_file=None)
-        result_help = self.template(["python", "-m", "viztracer", "--help"], expected_output_file=None)
+        result = self.template([sys.executable, "-m", "viztracer"], expected_output_file=None)
+        result_h = self.template([sys.executable, "-m", "viztracer", "-h"], expected_output_file=None)
+        result_help = self.template([sys.executable, "-m", "viztracer", "--help"], expected_output_file=None)
 
         self.assertEqual(result_h.stdout.decode("utf-8"), result_help.stdout.decode("utf-8"))
         self.assertEqual(result.stdout.decode("utf-8"), result_h.stdout.decode("utf-8"))
 
     def test_run(self):
-        self.template(["python", "-m", "viztracer", "cmdline_test.py"])
+        self.template([sys.executable, "-m", "viztracer", "cmdline_test.py"])
         self.template(["viztracer", "cmdline_test.py"])
 
     def test_cmd_string(self):
@@ -243,18 +243,18 @@ class TestCommandLineBasic(CmdlineTmpl):
 
     @package_matrix(["~orjson", "orjson"])
     def test_outputfile(self):
-        self.template(["python", "-m", "viztracer", "-o", "result.html", "cmdline_test.py"],
+        self.template([sys.executable, "-m", "viztracer", "-o", "result.html", "cmdline_test.py"],
                       expected_output_file="result.html")
-        self.template(["python", "-m", "viztracer", "-o", "result.json", "cmdline_test.py"])
-        self.template(["python", "-m", "viztracer", "-o", "result.json.gz", "cmdline_test.py"],
+        self.template([sys.executable, "-m", "viztracer", "-o", "result.json", "cmdline_test.py"])
+        self.template([sys.executable, "-m", "viztracer", "-o", "result.json.gz", "cmdline_test.py"],
                       expected_output_file="result.json.gz")
-        self.template(["python", "-m", "viztracer", "--output_file", "result.html", "cmdline_test.py"],
+        self.template([sys.executable, "-m", "viztracer", "--output_file", "result.html", "cmdline_test.py"],
                       expected_output_file="result.html")
-        self.template(["python", "-m", "viztracer", "--output_file", "result.json", "cmdline_test.py"],
+        self.template([sys.executable, "-m", "viztracer", "--output_file", "result.json", "cmdline_test.py"],
                       expected_output_file="result.json")
-        self.template(["python", "-m", "viztracer", "--output_file", "result with space.json", "cmdline_test.py"],
+        self.template([sys.executable, "-m", "viztracer", "--output_file", "result with space.json", "cmdline_test.py"],
                       expected_output_file="result with space.json")
-        self.template(["python", "-m", "viztracer", "--output_file", "result.json.gz", "cmdline_test.py"],
+        self.template([sys.executable, "-m", "viztracer", "--output_file", "result.json.gz", "cmdline_test.py"],
                       expected_output_file="result.json.gz")
         self.template(["viztracer", "-o", "result.html", "cmdline_test.py"], expected_output_file="result.html")
         self.template(["viztracer", "-o", "result.json", "cmdline_test.py"], expected_output_file="result.json")
@@ -281,69 +281,70 @@ class TestCommandLineBasic(CmdlineTmpl):
             self.assertRegex(os.listdir(tmpdir)[0], r"numbers_\d{8}_\d{6}_\d+\.json")
 
     def test_verbose(self):
-        result = self.template(["python", "-m", "viztracer", "cmdline_test.py"])
+        result = self.template([sys.executable, "-m", "viztracer", "cmdline_test.py"])
         self.assertTrue("Use the following command" in result.stdout.decode("utf8"))
-        result = self.template(["python", "-m", "viztracer", "--quiet", "cmdline_test.py"])
+        result = self.template([sys.executable, "-m", "viztracer", "--quiet", "cmdline_test.py"])
         self.assertFalse("Use the following command" in result.stdout.decode("utf8"))
 
     def test_max_stack_depth(self):
-        self.template(["python", "-m", "viztracer", "--max_stack_depth", "5", "cmdline_test.py"])
+        self.template([sys.executable, "-m", "viztracer", "--max_stack_depth", "5", "cmdline_test.py"])
         self.template(["viztracer", "--max_stack_depth", "5", "cmdline_test.py"])
 
     def test_include_files(self):
-        result = self.template(["python", "-m", "viztracer", "--include_files", "./abcd", "cmdline_test.py"],
+        result = self.template([sys.executable, "-m", "viztracer", "--include_files", "./abcd", "cmdline_test.py"],
                                expected_output_file=None)
         self.assertIn("help", result.stdout.decode("utf8"))
-        self.template(["python", "-m", "viztracer", "-o", "result.json", "--include_files", "./", "--run", "cmdline_test.py"],
+        py_exec = sys.executable
+        self.template([py_exec, "-m", "viztracer", "-o", "result.json", "--include_files", "./", "--run", "cmdline_test.py"],
                       expected_output_file="result.json", expected_entries=17)
-        self.template(["python", "-m", "viztracer", "-o", "result.json", "--include_files", "./", "--", "cmdline_test.py"],
+        self.template([py_exec, "-m", "viztracer", "-o", "result.json", "--include_files", "./", "--", "cmdline_test.py"],
                       expected_output_file="result.json", expected_entries=17)
-        self.template(["python", "-m", "viztracer", "--include_files", "./", "--max_stack_depth", "5", "cmdline_test.py"])
-        self.template(["python", "-m", "viztracer", "--include_files", "./abcd", "--run", "cmdline_test.py"])
+        self.template([py_exec, "-m", "viztracer", "--include_files", "./", "--max_stack_depth", "5", "cmdline_test.py"])
+        self.template([py_exec, "-m", "viztracer", "--include_files", "./abcd", "--run", "cmdline_test.py"])
 
     def test_exclude_files(self):
-        result = self.template(["python", "-m", "viztracer", "--exclude_files", "./abcd", "cmdline_test.py"],
+        result = self.template([sys.executable, "-m", "viztracer", "--exclude_files", "./abcd", "cmdline_test.py"],
                                expected_output_file=None)
         self.assertIn("help", result.stdout.decode("utf8"))
-        self.template(["python", "-m", "viztracer", "--exclude_files", "./", "-o", "result.json", "cmdline_test.py"],
+        self.template([sys.executable, "-m", "viztracer", "--exclude_files", "./", "-o", "result.json", "cmdline_test.py"],
                       expected_output_file="result.json", expected_entries=1)
-        self.template(["python", "-m", "viztracer", "--exclude_files", "./abcd", "--run", "cmdline_test.py"])
-        self.template(["python", "-m", "viztracer", "--exclude_files", "./abcd", "--", "cmdline_test.py"])
+        self.template([sys.executable, "-m", "viztracer", "--exclude_files", "./abcd", "--run", "cmdline_test.py"])
+        self.template([sys.executable, "-m", "viztracer", "--exclude_files", "./abcd", "--", "cmdline_test.py"])
 
     def test_ignore_c_function(self):
-        self.template(["python", "-m", "viztracer", "--ignore_c_function", "cmdline_test.py"], script=file_c_function)
+        self.template([sys.executable, "-m", "viztracer", "--ignore_c_function", "cmdline_test.py"], script=file_c_function)
 
     def test_log_func_retval(self):
-        self.template(["python", "-m", "viztracer", "--log_func_retval", "cmdline_test.py"], script=file_c_function)
+        self.template([sys.executable, "-m", "viztracer", "--log_func_retval", "cmdline_test.py"], script=file_c_function)
 
     def test_log_func_args(self):
-        self.template(["python", "-m", "viztracer", "--log_func_args", "cmdline_test.py"])
+        self.template([sys.executable, "-m", "viztracer", "--log_func_args", "cmdline_test.py"])
 
     def test_log_func_with_objprint(self):
-        self.template(["python", "-m", "viztracer", "--log_func_args", "--log_func_with_objprint", "cmdline_test.py"])
+        self.template([sys.executable, "-m", "viztracer", "--log_func_args", "--log_func_with_objprint", "cmdline_test.py"])
 
     def test_minimize_memory(self):
-        self.template(["python", "-m", "viztracer", "--minimize_memory", "cmdline_test.py"])
+        self.template([sys.executable, "-m", "viztracer", "--minimize_memory", "cmdline_test.py"])
 
     @package_matrix(["~orjson", "orjson"])
     def test_combine(self):
         example_json_dir = os.path.join(os.path.dirname(__file__), "../", "example/json")
-        self.template(["python", "-m", "viztracer", "--combine",
+        self.template([sys.executable, "-m", "viztracer", "--combine",
                        os.path.join(example_json_dir, "multithread.json"),
                        os.path.join(example_json_dir, "different_sorts.json")],
                       expected_output_file="result.json")
-        self.template(["python", "-m", "viztracer", "-o", "my_result.html", "--combine",
+        self.template([sys.executable, "-m", "viztracer", "-o", "my_result.html", "--combine",
                        os.path.join(example_json_dir, "multithread.json"),
                        os.path.join(example_json_dir, "different_sorts.json")],
                       expected_output_file="my_result.html")
-        self.template(["python", "-m", "viztracer", "--align_combine",
+        self.template([sys.executable, "-m", "viztracer", "--align_combine",
                        os.path.join(example_json_dir, "multithread.json"),
                        os.path.join(example_json_dir, "different_sorts.json")],
                       expected_output_file="result.json")
 
     def test_tracer_entries(self):
-        self.template(["python", "-m", "viztracer", "--tracer_entries", "1000", "cmdline_test.py"])
-        self.template(["python", "-m", "viztracer", "--tracer_entries", "50", "cmdline_test.py"])
+        self.template([sys.executable, "-m", "viztracer", "--tracer_entries", "1000", "cmdline_test.py"])
+        self.template([sys.executable, "-m", "viztracer", "--tracer_entries", "50", "cmdline_test.py"])
 
     def test_trace_self(self):
         def check_func(data):
@@ -359,12 +360,12 @@ class TestCommandLineBasic(CmdlineTmpl):
                           send_sig=(signal.SIGTERM, "Ctrl+C"), expected_output_file="result.json", check_func=check_func)
 
     def test_min_duration(self):
-        self.template(["python", "-m", "viztracer", "--min_duration", "1s", "cmdline_test.py"], expected_entries=0)
-        self.template(["python", "-m", "viztracer", "--min_duration", "0.0.3s", "cmdline_test.py"], success=False)
+        self.template([sys.executable, "-m", "viztracer", "--min_duration", "1s", "cmdline_test.py"], expected_entries=0)
+        self.template([sys.executable, "-m", "viztracer", "--min_duration", "0.0.3s", "cmdline_test.py"], success=False)
 
     def test_pid_suffix(self):
         result = self.template(
-            ["python", "-m", "viztracer", "--pid_suffix", "--output_dir", "./suffix_tmp", "cmdline_test.py"],
+            [sys.executable, "-m", "viztracer", "--pid_suffix", "--output_dir", "./suffix_tmp", "cmdline_test.py"],
             expected_output_file="./suffix_tmp", script=file_pid_suffix, cleanup=False
         )
         pid = result.stdout.decode("utf-8").split()[0]
@@ -373,7 +374,7 @@ class TestCommandLineBasic(CmdlineTmpl):
 
     def test_pid_suffix_and_output(self):
         result = self.template(
-            ["python", "-m", "viztracer", "--pid_suffix", "--output_dir", "./suffix_tmp", "-o", "test.json",
+            [sys.executable, "-m", "viztracer", "--pid_suffix", "--output_dir", "./suffix_tmp", "-o", "test.json",
              "cmdline_test.py"], expected_output_file="./suffix_tmp", script=file_pid_suffix, cleanup=False
         )
         pid = result.stdout.decode("utf-8").split()[0]
@@ -385,7 +386,7 @@ class TestCommandLineBasic(CmdlineTmpl):
 
     def test_import_star(self):
         script = "from viztracer import *"
-        self.template(["python", "cmdline_test.py"], script=script, expected_output_file=None)
+        self.template([sys.executable, "cmdline_test.py"], script=script, expected_output_file=None)
 
     def test_log_gc(self):
         self.template(["viztracer", "--log_gc", "cmdline_test.py"], script=file_gc)
@@ -567,13 +568,13 @@ class TestCommandLineBasic(CmdlineTmpl):
 
 class TestPossibleFailures(CmdlineTmpl):
     def test_main(self):
-        self.template(["python", "-m", "viztracer", "-o", "main.json", "cmdline_test.py"],
+        self.template([sys.executable, "-m", "viztracer", "-o", "main.json", "cmdline_test.py"],
                       expected_output_file="main.json",
                       script=file_main,
                       expected_entries=3)
 
     def test_argv(self):
-        self.template(["python", "-m", "viztracer", "cmdline_test.py"], script=file_argv)
+        self.template([sys.executable, "-m", "viztracer", "cmdline_test.py"], script=file_argv)
 
     def test_exit(self):
-        self.template(["python", "-m", "viztracer", "cmdline_test.py"], script=file_exit)
+        self.template([sys.executable, "-m", "viztracer", "cmdline_test.py"], script=file_exit)

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -294,13 +294,18 @@ class TestCommandLineBasic(CmdlineTmpl):
         result = self.template([sys.executable, "-m", "viztracer", "--include_files", "./abcd", "cmdline_test.py"],
                                expected_output_file=None)
         self.assertIn("help", result.stdout.decode("utf8"))
-        py_exec = sys.executable
-        self.template([py_exec, "-m", "viztracer", "-o", "result.json", "--include_files", "./", "--run", "cmdline_test.py"],
-                      expected_output_file="result.json", expected_entries=17)
-        self.template([py_exec, "-m", "viztracer", "-o", "result.json", "--include_files", "./", "--", "cmdline_test.py"],
-                      expected_output_file="result.json", expected_entries=17)
-        self.template([py_exec, "-m", "viztracer", "--include_files", "./", "--max_stack_depth", "5", "cmdline_test.py"])
-        self.template([py_exec, "-m", "viztracer", "--include_files", "./abcd", "--run", "cmdline_test.py"])
+        self.template(
+            [sys.executable, "-m", "viztracer", "-o", "result.json", "--include_files", "./", "--run", "cmdline_test.py"],
+            expected_output_file="result.json", expected_entries=17
+        )
+        self.template(
+            [sys.executable, "-m", "viztracer", "-o", "result.json", "--include_files", "./", "--", "cmdline_test.py"],
+            expected_output_file="result.json", expected_entries=17
+        )
+        self.template(
+            [sys.executable, "-m", "viztracer", "--include_files", "./", "--max_stack_depth", "5", "cmdline_test.py"]
+        )
+        self.template([sys.executable, "-m", "viztracer", "--include_files", "./abcd", "--run", "cmdline_test.py"])
 
     def test_exclude_files(self):
         result = self.template([sys.executable, "-m", "viztracer", "--exclude_files", "./abcd", "cmdline_test.py"],

--- a/tests/test_logsparse.py
+++ b/tests/test_logsparse.py
@@ -4,6 +4,7 @@
 import functools
 import multiprocessing
 import os
+import sys
 
 from .cmdline_tmpl import CmdlineTmpl
 
@@ -203,8 +204,8 @@ class TestLogSparse(CmdlineTmpl):
                       check_func=functools.partial(self.check_func, target=['f', 'g', 'f', 'g']))
 
     def test_without_tracer(self):
-        self.template(["python", "cmdline_test.py"], script=file_basic, expected_output_file=None)
-        self.template(["python", "cmdline_test.py"], script=file_stack, expected_output_file=None)
+        self.template([sys.executable, "cmdline_test.py"], script=file_basic, expected_output_file=None)
+        self.template([sys.executable, "cmdline_test.py"], script=file_stack, expected_output_file=None)
 
     def test_multiprocess(self):
         if multiprocessing.get_start_method() == "fork":
@@ -229,14 +230,14 @@ class TestLogSparse(CmdlineTmpl):
                       concurrency="multiprocessing")
 
     def test_context_manager(self):
-        self.template(["python", "cmdline_test.py"], script=file_context_manager,
+        self.template([sys.executable, "cmdline_test.py"], script=file_context_manager,
                       expected_output_file="result.json", expected_entries=4,
                       check_func=functools.partial(self.check_func, target=['f', 'g', 'h', 'q']))
 
-        self.template(["python", "cmdline_test.py"], script=file_context_manager_logsparse,
+        self.template([sys.executable, "cmdline_test.py"], script=file_context_manager_logsparse,
                       expected_output_file="result.json", expected_entries=2,
                       check_func=functools.partial(self.check_func, target=['f', 'q']))
 
-        self.template(["python", "cmdline_test.py"], script=file_context_manager_logsparse_stack,
+        self.template([sys.executable, "cmdline_test.py"], script=file_context_manager_logsparse_stack,
                       expected_output_file="result.json", expected_entries=2,
                       check_func=functools.partial(self.check_func, target=['g', 'h']))

--- a/tests/test_multiprocess.py
+++ b/tests/test_multiprocess.py
@@ -14,15 +14,17 @@ from .cmdline_tmpl import CmdlineTmpl
 
 file_grandparent = """
 import subprocess
-subprocess.run(["python", "parent.py"])
+import sys
+subprocess.run([sys.executable, "parent.py"])
 """
 
 
 file_parent = """
 import subprocess
-subprocess.run(["python", "child.py"])
-subprocess.run(("python", "child.py"))
-subprocess.run("python child.py")
+import sys
+subprocess.run([sys.executable, "child.py"])
+subprocess.run((sys.executable, "child.py"))
+subprocess.run(f"{sys.executable} child.py")
 """
 
 
@@ -43,22 +45,25 @@ while True:
 
 file_subprocess_module = """
 import subprocess
-print(subprocess.call(["python", "-m", "timeit", "-n", "100", "'1+1'"]))
+import sys
+print(subprocess.call([sys.executable, "-m", "timeit", "-n", "100", "'1+1'"]))
 """
 
 file_subprocess_code_string = """
 import subprocess
-p = subprocess.Popen(['python', '-c', 'import time;time.sleep(0.5)'])
+import sys
+p = subprocess.Popen([sys.executable, '-c', 'import time;time.sleep(0.5)'])
 p.wait()
 """
 
 file_subprocess_shell = """
-import subprocess
 import os
+import subprocess
+import sys
 with open(os.path.join(os.path.dirname(__file__), "sub.py"), "w") as f:
     f.write("print('hello')")
 path = os.path.join(os.path.dirname(__file__), "sub.py")
-print(subprocess.call(f"python {path}", shell=True))
+print(subprocess.call(f"{sys.executable} {path}", shell=True))
 """
 
 file_fork = """

--- a/tests/test_multithread.py
+++ b/tests/test_multithread.py
@@ -202,6 +202,6 @@ class TestMultithreadCmdline(CmdlineTmpl):
             self.assertGreaterEqual(len(set(e["tid"] for e in data["traceEvents"])), 3)
             self.assertTrue(any(e["name"] for e in data["traceEvents"] if e["name"].startswith("fib")))
 
-        self.template(["python", "cmdline_test.py"],
+        self.template([sys.executable, "cmdline_test.py"],
                       expected_output_file="result.json",
                       script=script, check_func=check_func)

--- a/tests/test_patch.py
+++ b/tests/test_patch.py
@@ -72,19 +72,20 @@ import sys
 with open("check_output_echo.py", "w") as f:
     f.write("import sys; print(sys.argv)")
 
-py_exec = sys.executable
-print(subprocess.check_output([py_exec, "--version"], text=True).strip())
-print(subprocess.check_output([py_exec, "-cprint(5)"]))
-print(subprocess.check_output([py_exec, "check_output_echo.py"], text=True))
-print(subprocess.check_output([py_exec, "-v", "--", "check_output_echo.py", "-a", "42"]))
-print(subprocess.check_output([py_exec, "-Es", "check_output_echo.py", "-v", "--my_arg=foo bar"], text=True))
-print(subprocess.check_output([py_exec, "-Esm", "check_output_echo", "-abc"]))
-print(subprocess.check_output([py_exec, "-c", r"import sys; sys.stdout.buffer.write(b'\0\1\2\3\4')"]))
-print(subprocess.check_output([py_exec, "-", "foo"], input=b"import sys; print(sys.argv)"))
-print(subprocess.check_output([py_exec], input=b"import sys; print(sys.argv)"))
-print(subprocess.check_output([py_exec, "-im", "check_output_echo", "asdf"], input=b"import sys; print(sys.argv)"))
-print(subprocess.check_output([py_exec, "check_output_echo.py", "test.py", "--output_dir", "test", "--other", "abc"]))
-print(subprocess.check_output([py_exec, "-m", "check_output_echo", "test.py", "--output_dir", "test", "--other", "abc"]))
+print(subprocess.check_output([sys.executable, "--version"], text=True).strip())
+print(subprocess.check_output([sys.executable, "-cprint(5)"]))
+print(subprocess.check_output([sys.executable, "check_output_echo.py"], text=True))
+print(subprocess.check_output([sys.executable, "-v", "--", "check_output_echo.py", "-a", "42"]))
+print(subprocess.check_output([sys.executable, "-Es", "check_output_echo.py", "-v", "--my_arg=foo bar"], text=True))
+print(subprocess.check_output([sys.executable, "-Esm", "check_output_echo", "-abc"]))
+print(subprocess.check_output([sys.executable, "-c", r"import sys; sys.stdout.buffer.write(b'\0\1\2\3\4')"]))
+print(subprocess.check_output([sys.executable, "-", "foo"], input=b"import sys; print(sys.argv)"))
+print(subprocess.check_output([sys.executable], input=b"import sys; print(sys.argv)"))
+print(subprocess.check_output([sys.executable, "-im", "check_output_echo", "asdf"], input=b"import sys; print(sys.argv)"))
+print(subprocess.check_output([sys.executable, "check_output_echo.py", "test.py", "--output_dir", "test", "--other", "abc"]))
+print(subprocess.check_output(
+    [sys.executable, "-m", "check_output_echo", "test.py", "--output_dir", "test", "--other", "abc"]
+))
 
 os.remove("check_output_echo.py")
 """

--- a/tests/test_patch.py
+++ b/tests/test_patch.py
@@ -40,7 +40,7 @@ assert multiprocessing.spawn._main.__qualname__ == "_main"
 assert multiprocessing.spawn._main.__module__ == "multiprocessing.spawn"
 
 argv = sys.argv
-sys.argv = ["python", "--multiprocessing-fork"]
+sys.argv = [sys.executable, "--multiprocessing-fork"]
 
 with open(parent_w, 'wb', closefd=False) as f:
     f.write(fp.getbuffer())
@@ -67,22 +67,24 @@ def foo():
 check_output = r"""
 import os
 import subprocess
+import sys
 
 with open("check_output_echo.py", "w") as f:
     f.write("import sys; print(sys.argv)")
 
-print(subprocess.check_output(["python", "--version"], text=True).strip())
-print(subprocess.check_output(["python", "-cprint(5)"]))
-print(subprocess.check_output(["python", "check_output_echo.py"], text=True))
-print(subprocess.check_output(["python", "-v", "--", "check_output_echo.py", "-a", "42"]))
-print(subprocess.check_output(["python", "-Es", "check_output_echo.py", "-v", "--my_arg=foo bar"], text=True))
-print(subprocess.check_output(["python", "-Esm", "check_output_echo", "-abc"]))
-print(subprocess.check_output(["python", "-c", r"import sys; sys.stdout.buffer.write(b'\0\1\2\3\4')"]))
-print(subprocess.check_output(["python", "-", "foo"], input=b"import sys; print(sys.argv)"))
-print(subprocess.check_output(["python"], input=b"import sys; print(sys.argv)"))
-print(subprocess.check_output(["python", "-im", "check_output_echo", "asdf"], input=b"import sys; print(sys.argv)"))
-print(subprocess.check_output(["python", "check_output_echo.py", "test.py", "--output_dir", "test", "--other", "abc"]))
-print(subprocess.check_output(["python", "-m", "check_output_echo", "test.py", "--output_dir", "test", "--other", "abc"]))
+py_exec = sys.executable
+print(subprocess.check_output([py_exec, "--version"], text=True).strip())
+print(subprocess.check_output([py_exec, "-cprint(5)"]))
+print(subprocess.check_output([py_exec, "check_output_echo.py"], text=True))
+print(subprocess.check_output([py_exec, "-v", "--", "check_output_echo.py", "-a", "42"]))
+print(subprocess.check_output([py_exec, "-Es", "check_output_echo.py", "-v", "--my_arg=foo bar"], text=True))
+print(subprocess.check_output([py_exec, "-Esm", "check_output_echo", "-abc"]))
+print(subprocess.check_output([py_exec, "-c", r"import sys; sys.stdout.buffer.write(b'\0\1\2\3\4')"]))
+print(subprocess.check_output([py_exec, "-", "foo"], input=b"import sys; print(sys.argv)"))
+print(subprocess.check_output([py_exec], input=b"import sys; print(sys.argv)"))
+print(subprocess.check_output([py_exec, "-im", "check_output_echo", "asdf"], input=b"import sys; print(sys.argv)"))
+print(subprocess.check_output([py_exec, "check_output_echo.py", "test.py", "--output_dir", "test", "--other", "abc"]))
+print(subprocess.check_output([py_exec, "-m", "check_output_echo", "test.py", "--output_dir", "test", "--other", "abc"]))
 
 os.remove("check_output_echo.py")
 """
@@ -102,7 +104,7 @@ class TestPatchSpawn(CmdlineTmpl):
     @unittest.skipIf(sys.platform == "win32", "pipe is different on windows so skip it")
     def test_patch_cmdline(self):
         tmpdir = tempfile.mkdtemp()
-        self.template(["python", "cmdline_test.py"],
+        self.template([sys.executable, "cmdline_test.py"],
                       expected_output_file=None,
                       script=file_spawn_tmpl.substitute(foo=foo_normal, tmpdir=tmpdir))
 
@@ -114,7 +116,7 @@ class TestPatchSpawn(CmdlineTmpl):
     @unittest.skipIf(sys.platform == "win32", "pipe is different on windows so skip it")
     def test_patch_terminate(self):
         tmpdir = tempfile.mkdtemp()
-        self.template(["python", "cmdline_test.py"],
+        self.template([sys.executable, "cmdline_test.py"],
                       expected_output_file=None,
                       script=file_spawn_tmpl.substitute(foo=foo_infinite, tmpdir=tmpdir),
                       send_sig=(signal.SIGTERM, "ready"))
@@ -125,7 +127,7 @@ class TestPatchSpawn(CmdlineTmpl):
         shutil.rmtree(tmpdir)
 
     def test_patch_args(self):
-        a = self.template(["python", "cmdline_test.py"],
+        a = self.template([sys.executable, "cmdline_test.py"],
                           expected_output_file=None,
                           script=check_output)
         b = self.template(["viztracer", "--quiet", "cmdline_test.py"],

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -327,7 +327,7 @@ class TestIssue508(CmdlineTmpl):
                 call_self(10)
         """
 
-        self.template(["python", "cmdline_test.py"], script=script,
+        self.template([sys.executable, "cmdline_test.py"], script=script,
                       expected_output_file="result.json",
                       expected_entries=6)
 

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -86,7 +86,7 @@ class TestRemote(CmdlineTmpl):
             f.write(file_to_attach)
 
         # Run the process to attach first
-        script_cmd = cmd_with_coverage(["python", "attached_script.py"])
+        script_cmd = cmd_with_coverage([sys.executable, "attached_script.py"])
         p_script = subprocess.Popen(script_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         try:
             pid_to_attach = p_script.pid
@@ -160,7 +160,7 @@ class TestRemote(CmdlineTmpl):
             f.write(file_to_attach)
 
         # Run the process to attach first
-        script_cmd = cmd_with_coverage(["python", "attached_script.py"])
+        script_cmd = cmd_with_coverage([sys.executable, "attached_script.py"])
         p_script = subprocess.Popen(script_cmd, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
         try:
             out = p_script.stdout.readline()
@@ -239,7 +239,7 @@ class TestAttachSanity(CmdlineTmpl):
             f.write(file_to_attach)
 
         # Run the process to attach first
-        script_cmd = cmd_with_coverage(["python", "attached_script.py"])
+        script_cmd = cmd_with_coverage([sys.executable, "attached_script.py"])
         p_script = subprocess.Popen(script_cmd, stdout=subprocess.PIPE)
         try:
             out = p_script.stdout.readline()
@@ -278,7 +278,7 @@ class TestAttachScript(CmdlineTmpl):
             print(viztracer.attach.attach_status.created_tracer, flush=True)
         """)
 
-        self.template(["python", "cmdline_test.py"],
+        self.template([sys.executable, "cmdline_test.py"],
                       script=attach_script,
                       expected_output_file="attach_test.json",
                       expected_stdout=re.compile(r".*?False.*?True.*?False.*?False.*?", re.DOTALL),

--- a/tests/test_report_builder.py
+++ b/tests/test_report_builder.py
@@ -6,6 +6,7 @@ import io
 import json
 import os
 import shutil
+import sys
 import tempfile
 import textwrap
 from unittest.mock import patch
@@ -155,4 +156,4 @@ class TestReportBuilderCmdline(CmdlineTmpl):
                     assert False
             """)
 
-            self.template(["python", "cmdline_test.py"], script=script, expected_output_file=None)
+            self.template([sys.executable, "cmdline_test.py"], script=script, expected_output_file=None)

--- a/tests/test_torch.py
+++ b/tests/test_torch.py
@@ -59,14 +59,14 @@ class TestTorch(CmdlineTmpl):
                         # Mac is pure crazy and we don't care about it
                         pass
 
-            self.template(["python", "cmdline_test.py"], script=script,
+            self.template([sys.executable, "cmdline_test.py"], script=script,
                           check_func=check_func)
         else:
             script = """
                 from viztracer import VizTracer
                 _ = VizTracer(log_torch=True, verbose=0)
             """
-            self.template(["python", "cmdline_test.py"], script=script,
+            self.template([sys.executable, "cmdline_test.py"], script=script,
                           expected_output_file=None, success=False,
                           expected_stderr=".*ModuleNotFoundError.*")
 

--- a/tests/test_vcompressor.py
+++ b/tests/test_vcompressor.py
@@ -6,6 +6,7 @@ import json
 import logging
 import lzma
 import os
+import sys
 import tempfile
 import unittest
 import zlib
@@ -273,7 +274,7 @@ class TestVCompressorPerformance(CmdlineTmpl):
             origin_json_path = os.path.join(tmpdir, "large_fib.json")
             run_script = test_large_fib % (origin_json_path.replace("\\", "/"))
             self.template(
-                ["python", "cmdline_test.py"], script=run_script, cleanup=False,
+                [sys.executable, "cmdline_test.py"], script=run_script, cleanup=False,
                 expected_output_file=origin_json_path,
             )
             original_size = os.path.getsize(origin_json_path)
@@ -490,7 +491,7 @@ class TestVCompressorCorrectness(CmdlineTmpl, VCompressorCompare):
             dup_json_path = os.path.join(tmpdir, "recovery.json")
             run_script = run_script % (origin_json_path.replace("\\", "/"))
             self.template(
-                ["python", "cmdline_test.py"],
+                [sys.executable, "cmdline_test.py"],
                 script=run_script,
                 cleanup=False,
                 expected_output_file=origin_json_path)

--- a/tests/util.py
+++ b/tests/util.py
@@ -44,7 +44,8 @@ def get_tests_data_file_path(filename):
 
 
 def cmd_with_coverage(cmd):
-    assert "python" not in cmd, "Do not use unqualified 'python' to launch intrepreter. Passing sys.executable is the recommended way."
+    assert "python" not in cmd, \
+        "Do not use unqualified 'python' to launch intrepreter. Passing sys.executable is the recommended way."
     if os.getenv("COVERAGE_RUN"):
         if cmd[0] == sys.executable:
             return ["coverage", "run", "--source", "viztracer", "--parallel-mode"] + cmd[1:]

--- a/tests/util.py
+++ b/tests/util.py
@@ -44,8 +44,9 @@ def get_tests_data_file_path(filename):
 
 
 def cmd_with_coverage(cmd):
+    assert "python" not in cmd, "Do not use unqualified 'python' to launch intrepreter. Passing sys.executable is the recommended way."
     if os.getenv("COVERAGE_RUN"):
-        if cmd[0] == "python" or cmd[0] == sys.executable:
+        if cmd[0] == sys.executable:
             return ["coverage", "run", "--source", "viztracer", "--parallel-mode"] + cmd[1:]
         elif cmd[0] == "viztracer":
             return ["coverage", "run", "--source", "viztracer", "--parallel-mode", "-m"] + cmd

--- a/tests/util.py
+++ b/tests/util.py
@@ -5,6 +5,7 @@ import json
 import os
 import re
 import subprocess
+import sys
 
 
 def generate_json(filename):
@@ -12,7 +13,7 @@ def generate_json(filename):
     cwd = os.getcwd()
     os.chdir(data_dir)
     path = os.path.join(os.path.dirname(__file__), "data", filename)
-    subprocess.run(["python", path], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    subprocess.run([sys.executable, path], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
     os.chdir(cwd)
 
 
@@ -44,7 +45,7 @@ def get_tests_data_file_path(filename):
 
 def cmd_with_coverage(cmd):
     if os.getenv("COVERAGE_RUN"):
-        if cmd[0] == "python":
+        if cmd[0] == "python" or cmd[0] == sys.executable:
             return ["coverage", "run", "--source", "viztracer", "--parallel-mode"] + cmd[1:]
         elif cmd[0] == "viztracer":
             return ["coverage", "run", "--source", "viztracer", "--parallel-mode", "-m"] + cmd


### PR DESCRIPTION
according to [subprocess.Popen warning](https://docs.python.org/3.10/library/subprocess.html#popen-constructor) the best way to run python is run it with full qualified path.

Original discussion - [venv subprocess call to python resolves to wrong interpreter #86207](https://github.com/python/cpython/issues/86207).

Should fix #282 