### PR TITLE
Support absolute timestamp of torch profiler before 2.4

### DIFF
--- a/src/viztracer/report_builder.py
+++ b/src/viztracer/report_builder.py
@@ -32,7 +32,10 @@ def get_json(data: Union[dict, str, tuple[str, dict]]) -> dict[str, Any]:
                 json_str = f.read()
             ret = json.loads(json_str)
             base_offset = args['base_offset']
-            torch_offset = ret['baseTimeNanoseconds']
+            # torch 2.4.0+ uses baseTimeNanoseconds to store the offset
+            # before that they simply use the absolute timestamp which is
+            # equivalent to baseTimeNanoseconds = 0
+            torch_offset = ret.get('baseTimeNanoseconds', 0)
             # convert to us
             offset_diff = (torch_offset - base_offset) / 1000
 
@@ -44,8 +47,8 @@ def get_json(data: Union[dict, str, tuple[str, dict]]) -> dict[str, Any]:
                     # process and thread names
                     event.pop('ts', None)
 
-            ret.pop("baseTimeNanoseconds")
-            ret.pop("displayTimeUnit")
+            ret.pop("baseTimeNanoseconds", None)
+            ret.pop("displayTimeUnit", None)
             ret.pop("traceName")
             ret.pop("deviceProperties")
             ret.pop("schemaVersion")


### PR DESCRIPTION
Starting pytorch 2.4.0 (I think), they used a basetime offset + relative timestamp for trace events. Before that (at least for 2.3.0 I tested) they were using absolute timestamp. This PR makes both schema supported.