### PR TITLE
Backward compatible with even older PyTorch

### DIFF
--- a/src/viztracer/report_builder.py
+++ b/src/viztracer/report_builder.py
@@ -49,7 +49,7 @@ def get_json(data: Union[dict, str, tuple[str, dict]]) -> dict[str, Any]:
 
             ret.pop("baseTimeNanoseconds", None)
             ret.pop("displayTimeUnit", None)
-            ret.pop("traceName")
+            ret.pop("traceName", None)
             ret.pop("deviceProperties")
             ret.pop("schemaVersion")
 


### PR DESCRIPTION
`traceName` was added in https://github.com/pytorch/kineto/pull/458. `viztracer` does not need the field, so it's safe skip dropping the field if the field was just not there. I verified that it works with PyTorch 1.11. 