### PR TITLE
Fix the bug that fails to trigger the event when ccall has an arg that's a method

### DIFF
--- a/src/viztracer/modules/snaptrace.c
+++ b/src/viztracer/modules/snaptrace.c
@@ -765,6 +765,12 @@ PyObject* get_cfunc_from_callable(PyObject* callable, PyObject* self_arg)
         if (PyCFunction_Check(meth)) {
             return (PyObject*)((PyCFunctionObject*)meth);
         }
+    } else if (Py_TYPE(callable) == &PyMethod_Type) {
+        PyObject* func = PyMethod_GET_FUNCTION(callable);
+        if (func && PyCFunction_Check(func)) {
+            Py_INCREF(func);
+            return func;
+        }
     }
     return NULL;
 }

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -7,6 +7,7 @@ import os
 import signal
 import sys
 import tempfile
+import textwrap
 import unittest
 
 import viztracer
@@ -330,6 +331,21 @@ class TestIssue508(CmdlineTmpl):
         self.template([sys.executable, "cmdline_test.py"], script=script,
                       expected_output_file="result.json",
                       expected_entries=6)
+
+
+class TestIssue552(CmdlineTmpl):
+    def test_issue552(self):
+        script = textwrap.dedent("""
+            from viztracer import VizTracer
+            class A:
+                f = classmethod(repr)
+            with VizTracer():
+                A().f()
+        """)
+
+        self.template([sys.executable, "cmdline_test.py"], script=script,
+                      expected_output_file="result.json",
+                      expected_entries=1)
 
 
 file_timestamp_disorder = """


### PR DESCRIPTION
close #552 