### PR TITLE
fix(decorator): fix trace and save in daemon process

### DIFF
--- a/src/viztracer/decorator.py
+++ b/src/viztracer/decorator.py
@@ -81,7 +81,10 @@ def trace_and_save(method: Optional[Callable[..., R]] = None,
             if not os.path.exists(output_dir):
                 os.mkdir(output_dir)
             file_name = os.path.join(output_dir, f"result_{func.__name__}_{int(100000 * time.time())}.json")
-            if multiprocessing.get_start_method() == "fork":
+            if (
+                multiprocessing.get_start_method() == "fork"
+                and not multiprocessing.process.current_process().daemon
+            ):
                 tracer.fork_save(file_name)
             else:
                 tracer.save(file_name)

--- a/tests/test_daemon_process.py
+++ b/tests/test_daemon_process.py
@@ -1,0 +1,27 @@
+# Licensed under the Apache License: http://www.apache.org/licenses/LICENSE-2.0
+# For details: https://github.com/gaogaotiantian/viztracer/blob/master/NOTICE.txt
+
+import multiprocessing as mp
+
+from viztracer.decorator import trace_and_save
+
+
+from .base_tmpl import BaseTmpl
+
+
+@trace_and_save(output_dir="/tmp/")
+def _foo():
+    print("foo")
+
+
+class TestDaemon(BaseTmpl):
+
+    def test_daemon(self):
+        # use fork to create a daemon process
+        mp.set_start_method("fork")
+        p = mp.Process(target=_foo, daemon=True)
+        p.daemon = True
+        p.start()
+        p.join()
+        # get return code of the process
+        self.assertEqual(p.exitcode, 0)


### PR DESCRIPTION
```
  File "/home/lz/.local/share/uv/python/cpython-3.10.16-linux-x86_64-gnu/lib/python3.10/multiprocessing/process.py", line 118, in start
    assert not _current_process._config.get('daemon'), \
AssertionError: daemonic processes are not allowed to have children
```
add condition if the current process is daemon

not sure why the multiprocessing.process uses `_config.get()` since to my testing `process.daemon` works fine. Maybe due to partly initiated object in some cases?