### PR TITLE
Call _threading_atexits in a reversed order

### DIFF
--- a/docs/source/custom_event_intro.rst
+++ b/docs/source/custom_event_intro.rst
@@ -19,7 +19,7 @@ argument ``args``. They will be displayed in the report
 ``args`` has to be a jsonifiable object, normally a string, or a combination
 of dict, list, string and number.
 
-``scope`` can be set to ``t``(default), ``p`` or ``g``, for thread, process and
+``scope`` can be set to ``t`` (default), ``p`` or ``g``, for thread, process and
 global.
 
 .. code-block:: python

--- a/src/viztracer/main.py
+++ b/src/viztracer/main.py
@@ -395,7 +395,7 @@ class VizUI:
         # release the resource in the code
         # Python 3.9+ has this issue
         if threading._threading_atexits:  # type: ignore
-            for atexit_call in threading._threading_atexits:  # type: ignore
+            for atexit_call in reversed(threading._threading_atexits):  # type: ignore
                 atexit_call()
             threading._threading_atexits = []  # type: ignore
 


### PR DESCRIPTION
It is better to call functions in `_threading_atexits` in the reverse order. Cleanup functions are always "first in, last out". The `threading` module does it too.