### PR TITLE
Call _threading_atexits in the reversed order

### DIFF
--- a/src/viztracer/main.py
+++ b/src/viztracer/main.py
@@ -395,7 +395,7 @@ class VizUI:
         # release the resource in the code
         # Python 3.9+ has this issue
         if threading._threading_atexits:  # type: ignore
-            for atexit_call in threading._threading_atexits:  # type: ignore
+            for atexit_call in reversed(threading._threading_atexits):  # type: ignore
                 atexit_call()
             threading._threading_atexits = []  # type: ignore
 

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -531,5 +531,5 @@ class TestThreadingExitOrder(CmdlineTmpl):
         self.template(
             ["viztracer", "cmdline_test.py"],
             script=threading_exit_order,
-            expected_stdout=r"hello world"
+            expected_stdout="hello world"
         )

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -524,7 +524,7 @@ import threading
 
 
 def print_data(arg):
-    print(arg)
+    print(arg, end="")
 
 
 if __name__ == "__main__":
@@ -538,5 +538,5 @@ class TestThreadingExitOrder(CmdlineTmpl):
         self.template(
             ["viztracer", "cmdline_test.py"],
             script=threading_exit_order,
-            expected_stdout=r"1\n2\n"
+            expected_stdout=r"12"
         )

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -525,7 +525,7 @@ class TestThreadingExitOrder(CmdlineTmpl):
             import threading
 
             if __name__ == "__main__":
-                threading._register_atexit(print, " world", end="")
+                threading._register_atexit(print, " world")
                 threading._register_atexit(print, "hello", end="")
             """
         self.template(

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -531,3 +531,26 @@ class TestDeadlock(CmdlineTmpl):
                       expected_output_file="result.json",
                       script=script,
                       check_func=check_func)
+
+
+threading_exit_order = """
+import threading
+
+
+def print_data(arg):
+    print(arg)
+
+
+if __name__ == "__main__":
+    threading._register_atexit(print_data, "2")
+    threading._register_atexit(print_data, "1")
+"""
+
+
+class TestThreadingExitOrder(CmdlineTmpl):
+    def test_threading_exit_order(self):
+        self.template(
+            ["viztracer", "cmdline_test.py"],
+            script=threading_exit_order,
+            expected_stdout=r"1\n2\n"
+        )

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -519,24 +519,17 @@ class TestFinalizerReference(CmdlineTmpl):
                       expected_stdout="success")
 
 
-threading_exit_order = """
-import threading
-
-
-def print_data(arg):
-    print(arg, end="")
-
-
-if __name__ == "__main__":
-    threading._register_atexit(print_data, "2")
-    threading._register_atexit(print_data, "1")
-"""
-
-
 class TestThreadingExitOrder(CmdlineTmpl):
     def test_threading_exit_order(self):
+        threading_exit_order = """
+            import threading
+
+            if __name__ == "__main__":
+                threading._register_atexit(print, " world", end="")
+                threading._register_atexit(print, "hello", end="")
+            """
         self.template(
             ["viztracer", "cmdline_test.py"],
             script=threading_exit_order,
-            expected_stdout=r"12"
+            expected_stdout=r"hello world"
         )


### PR DESCRIPTION
It is better to call functions in `_threading_atexits` in the reverse order. Cleanup functions are always "first in, last out". The `threading` module does this too ( in the function `_shutdown`, which is invoked by CPython internals when exiting).