### PR TITLE
fix 591: addressing issues with forked processes

### DIFF
--- a/src/viztracer/modules/snaptrace.c
+++ b/src/viztracer/modules/snaptrace.c
@@ -513,6 +513,8 @@ tracer_pyreturn_callback(TracerObject* self, PyCodeObject* code, PyObject* arg)
         goto cleanup_ignore;
     }
 
+    if (info->curr_stack_depth == 0) goto cleanup_ignore;
+
     struct FunctionNode* stack_top = info->stack_top;
     if (stack_top->prev) {
         // if stack_top has prev, it's not the fake node so it's at least root
@@ -601,6 +603,8 @@ tracer_creturn_callback(TracerObject* self, PyCodeObject* code, PyObject* arg)
         // have the -1 case.
         goto cleanup_ignore;
     }
+
+    if (info->curr_stack_depth == 0) goto cleanup_ignore;
 
     struct FunctionNode* stack_top = info->stack_top;
     if (stack_top->prev) {
@@ -1700,6 +1704,7 @@ tracer_setcurrstack(TracerObject* self, PyObject* stack_depth)
     }
 
     info->curr_stack_depth = PyLong_AsLong(stack_depth);
+    info->ignore_stack_depth = info->curr_stack_depth;
 
     Py_RETURN_NONE;
 }

--- a/src/viztracer/patch.py
+++ b/src/viztracer/patch.py
@@ -118,7 +118,7 @@ def patch_multiprocessing(tracer: VizTracer, viz_args: list[str]) -> None:
         tracer.register_exit()
 
         tracer.clear()
-        tracer._set_curr_stack_depth(1)
+        tracer._set_curr_stack_depth(0)
 
         if tracer._afterfork_cb:
             tracer._afterfork_cb(tracer, *tracer._afterfork_args, **tracer._afterfork_kwargs)


### PR DESCRIPTION
It sort of works with the example in the issue, except that (some of?) the parent process pre-fork stack is still shown for the forked process. I.e. it might take some mental capacity to understand when exactly the fork happened. Yet, I was able to finally profile a complex application with forking subprocesses using this patch.