### PR TITLE
Use modern CPython APIs for performance

### DIFF
--- a/src/viztracer/modules/snaptrace.c
+++ b/src/viztracer/modules/snaptrace.c
@@ -421,7 +421,7 @@ tracer_pycall_callback(TracerObject* self, PyCodeObject* code)
         info->paused = 1;
         for (size_t i = 0; i < sizeof(curr_task_getters)/sizeof(curr_task_getters[0]); i++) {
             if (curr_task_getters[i] != NULL) {
-                curr_task = PyObject_CallObject(curr_task_getters[i], NULL);
+                curr_task = PyObject_CallNoArgs(curr_task_getters[i]);
                 if (!curr_task) {
                     PyErr_Clear();  // RuntimeError, probably
                     curr_task = Py_None;
@@ -1204,7 +1204,7 @@ tracer_load(TracerObject* self, PyObject* Py_UNUSED(unused))
                 perror("Failed to access multiprocessing.current_process()");
                 exit(-1);
             }
-            PyObject* current_process = PyObject_CallObject(current_process_method, NULL);
+            PyObject* current_process = PyObject_CallNoArgs(current_process_method);
             if (!current_process_method) {
                 perror("Failed to access multiprocessing.current_process()");
                 exit(-1);
@@ -1272,7 +1272,7 @@ tracer_load(TracerObject* self, PyObject* Py_UNUSED(unused))
                     PyObject* task_name = NULL;
                     if (PyObject_HasAttrString(curr->data.fee.asyncio_task, "get_name")) {
                         PyObject* task_name_method = PyObject_GetAttrString(curr->data.fee.asyncio_task, "get_name");
-                        task_name = PyObject_CallObject(task_name_method, NULL);
+                        task_name = PyObject_CallNoArgs(task_name_method);
                         Py_DECREF(task_name_method);
                     } else if (PyObject_HasAttrString(curr->data.fee.asyncio_task, "name")) {
                         task_name = PyObject_GetAttrString(curr->data.fee.asyncio_task, "name");
@@ -1458,7 +1458,7 @@ tracer_dump(TracerObject* self, PyObject* args, PyObject* kw)
                 perror("Failed to access multiprocessing.current_process()");
                 exit(-1);
             }
-            PyObject* current_process = PyObject_CallObject(current_process_method, NULL);
+            PyObject* current_process = PyObject_CallNoArgs(current_process_method);
             if (!current_process_method) {
                 perror("Failed to access multiprocessing.current_process()");
                 exit(-1);
@@ -1504,7 +1504,7 @@ tracer_dump(TracerObject* self, PyObject* args, PyObject* kw)
                     PyObject* task_name = NULL;
                     if (PyObject_HasAttrString(curr->data.fee.asyncio_task, "get_name")) {
                         PyObject* task_name_method = PyObject_GetAttrString(curr->data.fee.asyncio_task, "get_name");
-                        task_name = PyObject_CallObject(task_name_method, NULL);
+                        task_name = PyObject_CallNoArgs(task_name_method);
                         Py_DECREF(task_name_method);
                     } else if (PyObject_HasAttrString(curr->data.fee.asyncio_task, "name")) {
                         task_name = PyObject_GetAttrString(curr->data.fee.asyncio_task, "name");

--- a/src/viztracer/modules/util.c
+++ b/src/viztracer/modules/util.c
@@ -20,13 +20,9 @@ void
 fprintjson(FILE* fptr, PyObject* obj)
 {
     PyObject* json_dumps = PyObject_GetAttrString(json_module, "dumps");
-    PyObject* call_args = PyTuple_New(1);
-    PyTuple_SetItem(call_args, 0, obj);
-    Py_INCREF(obj);
-    PyObject* args_str = PyObject_CallObject(json_dumps, call_args);
+    PyObject* args_str = PyObject_CallOneArg(json_dumps, obj);
     fprintf(fptr, "%s", PyUnicode_AsUTF8(args_str));
     Py_DECREF(json_dumps);
-    Py_DECREF(call_args);
     Py_DECREF(args_str);
 }
 

--- a/src/viztracer/modules/vcompressor/vc_dump.c
+++ b/src/viztracer/modules/vcompressor/vc_dump.c
@@ -188,7 +188,6 @@ PyObject*
 json_dumps_to_bytes(PyObject* json_data)
 {
     PyObject* json_ret      = NULL;
-    PyObject* json_args     = NULL;
     PyObject* bytes_data    = NULL;
     PyObject* dumps_func    = NULL;
 
@@ -202,11 +201,7 @@ json_dumps_to_bytes(PyObject* json_data)
     }
 
     // json dumps json_data
-    json_args = PyTuple_New(1);
-    PyTuple_SetItem(json_args, 0, json_data);
-    Py_INCREF(json_data); 
-    json_ret = PyObject_CallObject(dumps_func, json_args);
-    Py_DECREF(json_args);
+    json_ret = PyObject_CallOneArg(dumps_func, json_data);
     if (!json_ret) {
         goto clean_exit;
     }
@@ -240,7 +235,6 @@ json_loads_from_bytes(PyObject* bytes_data)
 {
     PyObject* loads_func    = NULL;
     PyObject* string_data   = NULL;
-    PyObject* json_args     = NULL;
     PyObject* json_data     = NULL;
 
     if (!PyBytes_Check(bytes_data)) {
@@ -261,10 +255,7 @@ json_loads_from_bytes(PyObject* bytes_data)
     }
 
     // convert string to json
-    json_args = PyTuple_New(1);
-    PyTuple_SetItem(json_args, 0, string_data);
-    json_data = PyObject_CallObject(loads_func, json_args);
-    Py_DECREF(json_args);
+    json_data = PyObject_CallOneArg(loads_func, string_data);
     if (!json_data) {
         goto clean_exit;
     }
@@ -283,7 +274,6 @@ clean_exit:
 PyObject*
 compress_bytes(PyObject* bytes_data)
 {
-    PyObject* zlib_args         = NULL;
     PyObject* compress_func     = NULL;
     PyObject* compressed_data   = NULL;
 
@@ -298,12 +288,7 @@ compress_bytes(PyObject* bytes_data)
         goto clean_exit;
     }
 
-    zlib_args = PyTuple_New(1);
-    PyTuple_SetItem(zlib_args, 0, bytes_data);
-    Py_INCREF(bytes_data);
-    compressed_data = PyObject_CallObject(compress_func, zlib_args);
-    // zlib_args steals bytes_data, so release zlib_args will release bytes_data
-    Py_DECREF(zlib_args);
+    compressed_data = PyObject_CallOneArg(compress_func, bytes_data);
     if (!compressed_data) {
         goto clean_exit;
     }
@@ -328,7 +313,6 @@ PyObject*
 decompress_bytes(PyObject* bytes_data)
 {
     // decompress data
-    PyObject* zlib_args = NULL;
     PyObject* decompressed_data = NULL;
     PyObject* decompress_func = NULL;
 
@@ -343,11 +327,7 @@ decompress_bytes(PyObject* bytes_data)
         goto clean_exit;
     }
 
-    zlib_args = PyTuple_New(1);
-    PyTuple_SetItem(zlib_args, 0, bytes_data);
-    Py_INCREF(bytes_data);
-    decompressed_data = PyObject_CallObject(decompress_func, zlib_args);
-    Py_DECREF(zlib_args);
+    decompressed_data = PyObject_CallOneArg(decompress_func, bytes_data);
     if (!decompressed_data) {
         goto clean_exit;
     }

--- a/src/viztracer/modules/vcompressor/vcompressor.c
+++ b/src/viztracer/modules/vcompressor/vcompressor.c
@@ -95,17 +95,17 @@ parse_trace_events(PyObject* trace_events)
                 Py_INCREF(pid);
                 Py_INCREF(tid);
                 Py_INCREF(name);
-                PyTuple_SetItem(key, 0, pid);
-                PyTuple_SetItem(key, 1, tid);
-                PyTuple_SetItem(key, 2, name);
+                PyTuple_SET_ITEM(key, 0, pid);
+                PyTuple_SET_ITEM(key, 1, tid);
+                PyTuple_SET_ITEM(key, 2, name);
 
                 // This indicates that if there's args in fee
                 fee_args = PyDict_GetItemString(event, "args");
                 if (fee_args) {
-                    PyTuple_SetItem(key, 3, Py_True);
+                    PyTuple_SET_ITEM(key, 3, Py_True);
                     Py_INCREF(Py_True);
                 } else {
-                    PyTuple_SetItem(key, 3, Py_False);
+                    PyTuple_SET_ITEM(key, 3, Py_False);
                     Py_INCREF(Py_False);
                 }
 
@@ -126,11 +126,11 @@ parse_trace_events(PyObject* trace_events)
                 
                 Py_INCREF(ts);
                 Py_INCREF(dur);
-                PyTuple_SetItem(ts_dur_tuple, 0, ts);
-                PyTuple_SetItem(ts_dur_tuple, 1, dur);
+                PyTuple_SET_ITEM(ts_dur_tuple, 0, ts);
+                PyTuple_SET_ITEM(ts_dur_tuple, 1, dur);
 
                 if (fee_args) {
-                    PyTuple_SetItem(ts_dur_tuple, 2, fee_args);
+                    PyTuple_SET_ITEM(ts_dur_tuple, 2, fee_args);
                     Py_INCREF(fee_args);
                 }
                 
@@ -154,8 +154,8 @@ parse_trace_events(PyObject* trace_events)
                 // PyTuple_SetItem steals reference
                 Py_INCREF(pid);
                 Py_INCREF(tid);
-                PyTuple_SetItem(id_key, 0, pid);
-                PyTuple_SetItem(id_key, 1, tid);
+                PyTuple_SET_ITEM(id_key, 0, pid);
+                PyTuple_SET_ITEM(id_key, 1, tid);
 
                 if (PyUnicode_CompareWithASCIIString(name, "process_name") == 0) {
                     PyDict_SetItem(process_names, id_key, args_name);
@@ -185,9 +185,9 @@ parse_trace_events(PyObject* trace_events)
                 Py_INCREF(name);
                 Py_INCREF(pid);
                 Py_INCREF(tid);
-                PyTuple_SetItem(counter_id_key, 0, pid);
-                PyTuple_SetItem(counter_id_key, 1, tid);
-                PyTuple_SetItem(counter_id_key, 2, name);
+                PyTuple_SET_ITEM(counter_id_key, 0, pid);
+                PyTuple_SET_ITEM(counter_id_key, 1, tid);
+                PyTuple_SET_ITEM(counter_id_key, 2, name);
                 if (!PyDict_Contains(counter_events, counter_id_key)){
                     counter_event_dict = PyDict_New();
                     PyDict_SetItem(counter_events, counter_id_key, counter_event_dict);


### PR DESCRIPTION
This PR:

* switches some invocations to the new-in-Python-3.9+ efficient `PyObject_CallNoArgs` and `PyObject_CallOneArg` APIs 
* switches to using the no-bounds-checked-be-very-careful `PyTuple_SET_ITEM` APIs for filling in new tuples