### PR TITLE
Speed up CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,16 +7,13 @@ on:
 
 jobs:
   lint:
-    strategy:
-      matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: '3.13'
       - name: Install dependency
         run: pip install flake8 mypy
       - name: Run flake8

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -33,13 +33,9 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.11
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install build twine flake8 setuptools wheel
+          python-version: '3.13'
 
-      - name: Install cibuildwheel
+      - name: Install dependencies
         run: python -m pip install cibuildwheel -U
 
       - name: Build wheels
@@ -64,13 +60,9 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install build twine flake8 setuptools wheel
+          python-version: '3.13'
 
-      - name: Install cibuildwheel
+      - name: Install dependencies
         run: python -m pip install cibuildwheel -U
 
       - name: Build wheels


### PR DESCRIPTION
* don't install unnecessary dependencies for cibuildwheel
* run lints only on the modernest Python