### PR TITLE
add option `log_callsite` to record function callsite (filepath:lineno)

### DIFF
--- a/src/viztracer/modules/eventnode.c
+++ b/src/viztracer/modules/eventnode.c
@@ -11,10 +11,11 @@ void
 clear_node(struct EventNode* node) {
     switch (node->ntype) {
     case FEE_NODE:
+        // Clear common optional fields
+        Py_CLEAR(node->data.fee.args);
+        Py_CLEAR(node->data.fee.retval);
         if (node->data.fee.type == PyTrace_CALL || node->data.fee.type == PyTrace_RETURN) {
             Py_CLEAR(node->data.fee.code);
-            Py_CLEAR(node->data.fee.args);
-            Py_CLEAR(node->data.fee.retval);
         } else {
             node->data.fee.ml_name = NULL;
             if (node->data.fee.m_module) {

--- a/src/viztracer/modules/snaptrace.h
+++ b/src/viztracer/modules/snaptrace.h
@@ -59,6 +59,7 @@
 #define SNAPTRACE_IGNORE_FROZEN (1 << 7)
 #define SNAPTRACE_LOG_ASYNC (1 << 8)
 #define SNAPTRACE_TRACE_SELF (1 << 9)
+#define SNAPTRACE_LOG_CALLSITE (1 << 10)
 
 #define SET_FLAG(reg, flag) ((reg) |= (flag))
 #define UNSET_FLAG(reg, flag) ((reg) &= (~(flag)))

--- a/src/viztracer/modules/snaptrace_member.c
+++ b/src/viztracer/modules/snaptrace_member.c
@@ -464,6 +464,9 @@ Tracer_log_func_repr_getter(TracerObject* self, void* closure)
     return Py_NewRef(self->log_func_repr);
 }
 
+static int Tracer_log_callsite_setter(TracerObject* self, PyObject* value, void* closure);
+static PyObject* Tracer_log_callsite_getter(TracerObject* self, void* closure);
+
 PyGetSetDef Tracer_getsetters[] = {
     {"max_stack_depth", (getter)Tracer_max_stack_depth_getter, (setter)Tracer_max_stack_depth_setter, "max_stack_depth", NULL},
     {"include_files", (getter)Tracer_include_files_getter, (setter)Tracer_include_files_setter, "include_files", NULL},
@@ -476,8 +479,40 @@ PyGetSetDef Tracer_getsetters[] = {
     {"min_duration", (getter)Tracer_min_duration_getter, (setter)Tracer_min_duration_setter, "min_duration", NULL},
     {"log_func_retval", (getter)Tracer_log_func_retval_getter, (setter)Tracer_log_func_retval_setter, "log_func_retval", NULL},
     {"log_func_args", (getter)Tracer_log_func_args_getter, (setter)Tracer_log_func_args_setter, "log_func_args", NULL},
+    {"log_callsite", (getter)Tracer_log_callsite_getter, (setter)Tracer_log_callsite_setter, "log_callsite", NULL},
     {"log_async", (getter)Tracer_log_async_getter, (setter)Tracer_log_async_setter, "log_async", NULL},
     {"trace_self", (getter)Tracer_trace_self_getter, (setter)Tracer_trace_self_setter, "trace_self", NULL},
     {"log_func_repr", (getter)Tracer_log_func_repr_getter, (setter)Tracer_log_func_repr_setter, "log_func_repr", NULL},
     {NULL}
 };
+
+static int
+Tracer_log_callsite_setter(TracerObject* self, PyObject* value, void* closure)
+{
+    if (value == NULL) {
+        PyErr_SetString(PyExc_AttributeError, "Cannot delete the attribute");
+        return -1;
+    }
+
+    if (!PyBool_Check(value)) {
+        PyErr_SetString(PyExc_TypeError, "log_callsite must be a boolean");
+        return -1;
+    }
+
+    if (value == Py_True) {
+        SET_FLAG(self->check_flags, SNAPTRACE_LOG_CALLSITE);
+    } else {
+        UNSET_FLAG(self->check_flags, SNAPTRACE_LOG_CALLSITE);
+    }
+    return 0;
+}
+
+static PyObject*
+Tracer_log_callsite_getter(TracerObject* self, void* closure)
+{
+    if (CHECK_FLAG(self->check_flags, SNAPTRACE_LOG_CALLSITE)) {
+        Py_RETURN_TRUE;
+    } else {
+        Py_RETURN_FALSE;
+    }
+}

--- a/src/viztracer/viztracer.py
+++ b/src/viztracer/viztracer.py
@@ -32,6 +32,7 @@ class VizTracer(Tracer):
                  ignore_frozen: bool = False,
                  log_func_retval: bool = False,
                  log_func_args: bool = False,
+                 log_callsite: bool = False,
                  log_func_repr: Callable[..., str] | None = None,
                  log_func_with_objprint: bool = False,
                  log_print: bool = False,
@@ -60,6 +61,7 @@ class VizTracer(Tracer):
         self.ignore_frozen = ignore_frozen
         self.log_func_args = log_func_args
         self.log_func_retval = log_func_retval
+        self.log_callsite = log_callsite
         self.log_async = log_async
         self.log_gc = log_gc
         self.log_print = log_print
@@ -149,6 +151,7 @@ class VizTracer(Tracer):
             "ignore_frozen": self.ignore_frozen,
             "log_func_retval": self.log_func_retval,
             "log_func_args": self.log_func_args,
+            "log_callsite": self.log_callsite,
             "log_print": self.log_print,
             "log_gc": self.log_gc,
             "log_sparse": self.log_sparse,


### PR DESCRIPTION
Overview
- Callsite is critical when analyzing complex code paths. For example, when I find the function `FA` takes a lot of time, I want to find where `FA` is triggered. 
- I add an option `log_callsite` to record function callsite (`filepath:lineno`).
- Disabled by default; when enabled, writes callsite into event metadata and shows in the report.

<img width="3720" height="956" alt="image" src="https://github.com/user-attachments/assets/39b376ac-f4fd-488e-90b3-11fd29402f8e" />


Design & Implementation
- Python API: `VizTracer(log_callsite=True)`.

