### PR TITLE
Use zstd for multiprocess IPC compression when available

### DIFF
--- a/src/viztracer/ipc_compression.py
+++ b/src/viztracer/ipc_compression.py
@@ -1,0 +1,28 @@
+# Licensed under the Apache License: http://www.apache.org/licenses/LICENSE-2.0
+# For details: https://github.com/gaogaotiantian/viztracer/blob/master/NOTICE.txt
+
+import zlib
+
+_ZSTD_MAGIC = b"zstd"
+
+try:
+    # `compression.zstd` is available on Python 3.14+ when
+    # compiled in to the build.
+    from compression import zstd  # type: ignore
+
+    def ipc_compress(data: bytes | bytearray) -> bytes:
+        return _ZSTD_MAGIC + zstd.compress(data)
+
+    def ipc_decompress(data: bytes | bytearray) -> bytes:
+        if data.startswith(_ZSTD_MAGIC):
+            return zstd.decompress(data[4:])
+        # Fallback for data compressed by an older viztracer (zlib)
+        return zlib.decompress(data)
+
+except ImportError:
+
+    def ipc_compress(data: bytes | bytearray) -> bytes:
+        return zlib.compress(data, level=1)  # Cheap compression level
+
+    def ipc_decompress(data: bytes | bytearray) -> bytes:
+        return zlib.decompress(data)

--- a/src/viztracer/report_server.py
+++ b/src/viztracer/report_server.py
@@ -10,8 +10,8 @@ import socket
 import subprocess
 import sys
 import tempfile
-import zlib
 
+from .ipc_compression import ipc_decompress
 from .report_builder import ReportBuilder
 from .util import same_line_print
 
@@ -178,7 +178,7 @@ class ReportServer:
         while d := conn.recv(1 << 20):
             buffer += d
         try:
-            data = json.loads(zlib.decompress(buffer).decode().strip())
+            data = json.loads(ipc_decompress(buffer).decode().strip())
             if "output_file" in data:
                 self.output_file = data["output_file"]
             if "payload" in data:

--- a/src/viztracer/viztracer.py
+++ b/src/viztracer/viztracer.py
@@ -14,12 +14,12 @@ import socket
 import subprocess
 import sys
 import warnings
-import zlib
 from typing import Any, Callable, Literal, Sequence, TextIO
 
 from viztracer.snaptrace import Tracer
 
 from . import __version__
+from .ipc_compression import ipc_compress
 from .patch import install_all_hooks, uninstall_all_hooks
 from .report_builder import ReportBuilder
 from .report_server import ReportServer
@@ -530,8 +530,9 @@ class VizTracer(Tracer):
             data = {"path": tmp_output_file, "payload": payload.getvalue()}
             if self.report_server_process is not None:
                 data["output_file"] = output_file
+
             self.report_socket_file.write(
-                zlib.compress(json.dumps(data).encode("utf-8"))
+                ipc_compress(json.dumps(data).encode("utf-8"))
             )
             self.report_socket_file.flush()
             self.report_socket_file.close()


### PR DESCRIPTION
A lot of time was being spent in `zlib_compress`; on modern Pythons, we can use zstd for free.

Refs #674 (and conflicts with it).