### PR TITLE
Map CUPTI thread names to Python thread names to fix thread duplications

### DIFF
--- a/src/viztracer/modules/snaptrace.c
+++ b/src/viztracer/modules/snaptrace.c
@@ -4,6 +4,7 @@
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
 #include <stdlib.h>
+#include <string.h>
 #include <frameobject.h>
 #if _WIN32
 #include <windows.h>
@@ -196,6 +197,53 @@ snaptrace_createthreadinfo(TracerObject* self) {
     info->tid = syscall(SYS_gettid);
 #endif
 
+    // Note [pthread-id-for-kineto-remap]:
+    //
+    // Problem: When VizTracer's `log_torch=True` merges a PyTorch/Kineto
+    // Chrome trace into the VizTracer trace, CUDA runtime events
+    // (e.g. `cudaLaunchKernel`, `cudaStreamSynchronize`) from worker
+    // threads appear on extra unnamed thread rows in Perfetto instead of
+    // on the Python threads that issued them.
+    //
+    // Root cause: VizTracer identifies threads by `SYS_gettid` (Linux
+    // kernel TID), but CUPTI reports `activity->threadId` as
+    // `pthread_self()` truncated to `int32_t`. Kineto's
+    // `handleRuntimeActivity()` (in `CuptiActivityProfiler.cpp`) tries
+    // to remap that to `SYS_gettid` via its `resourceInfo_` map, but
+    // that map is only populated by `recordThreadInfo()`, which is only
+    // called from `ThreadLocalSubqueue`'s constructor, which only runs
+    // on threads that fire `RecordFunction` callbacks. Since
+    // `torch.profiler.profile()` registers callbacks via
+    // `at::addThreadLocalCallback()` (not global), only the thread that
+    // called `profile().__enter__()` gets callbacks -- worker threads
+    // (e.g. `image_executor` from `ThreadPoolExecutor`) never fire
+    // `RecordFunction`, so they are never registered in `resourceInfo_`,
+    // and their CUDA events keep raw `pthread_self()` values as `tid`.
+    // In a single-threaded program this is invisible because the main
+    // thread (which started the profiler) IS registered, so Kineto
+    // remaps its CUDA events correctly. The problem only manifests
+    // when CUDA calls happen on additional worker threads.
+    //
+    // Fix: We record `pthread_self()` for each thread that VizTracer
+    // sees, building a `pthread_self()` -> `SYS_gettid` mapping.
+    // `report_builder.py` uses this mapping to rewrite `tid` values in
+    // the Kineto trace before merging, so CUDA events land on the
+    // correct Python thread rows.
+    //
+    // Kineto truncates `pthread_self()` to lower 32 bits via `int32_t*`
+    // reinterpret cast (see `threadId()` in kineto's `ThreadUtil.cpp`).
+    // We replicate that so our mapping matches Kineto's `tid` values.
+    int32_t pthread_id_i32;
+#if _WIN32
+    pthread_id_i32 = (int32_t)GetCurrentThreadId();
+#else
+    {
+        pthread_t pth = pthread_self();
+        memcpy(&pthread_id_i32, &pth, sizeof(pthread_id_i32));
+    }
+#endif
+    unsigned long pthread_id = (unsigned long)(uint32_t)pthread_id_i32;
+
 #if _WIN32
     TlsSetValue(self->dwTlsIndex, info);
 #else
@@ -227,6 +275,7 @@ snaptrace_createthreadinfo(TracerObject* self) {
         if (node->tid == info->tid) {
             Py_DECREF(node->name);
             node->name = thread_name;
+            node->pthread_id = pthread_id;
             node->thread_info = info;
             info->metadata_node = node;
             found_node = 1;
@@ -244,6 +293,7 @@ snaptrace_createthreadinfo(TracerObject* self) {
         }
         node->name = thread_name;
         node->tid = info->tid;
+        node->pthread_id = pthread_id;
         node->thread_info = info;
         info->metadata_node = node;
         node->next = self->metadata_head;
@@ -1689,6 +1739,34 @@ tracer_getbasetime(TracerObject* self, PyObject* Py_UNUSED(unused))
     return PyLong_FromLongLong(get_base_time_ns());
 }
 
+// See note [pthread-id-for-kineto-remap].
+// Returns a Python dict mapping `pthread_id` (Kineto's truncated `pthread_self()`)
+// to `tid` (`SYS_gettid`) for every thread VizTracer has seen.
+static PyObject*
+tracer_getpthreadidmap(TracerObject* self, PyObject* Py_UNUSED(unused))
+{
+    PyObject* dict = PyDict_New();
+    if (!dict) {
+        return NULL;
+    }
+    struct MetadataNode* node = self->metadata_head;
+    while (node) {
+        PyObject* key = PyLong_FromUnsignedLong(node->pthread_id);
+        PyObject* val = PyLong_FromUnsignedLong(node->tid);
+        if (!key || !val) {
+            Py_XDECREF(key);
+            Py_XDECREF(val);
+            Py_DECREF(dict);
+            return NULL;
+        }
+        PyDict_SetItem(dict, key, val);
+        Py_DECREF(key);
+        Py_DECREF(val);
+        node = node->next;
+    }
+    return dict;
+}
+
 static PyObject*
 tracer_resetstack(TracerObject* self, PyObject* Py_UNUSED(unused))
 {
@@ -1982,6 +2060,7 @@ static PyMethodDef Tracer_methods[] = {
     {"get_func_args", (PyCFunction)tracer_getfunctionarg, METH_NOARGS, "get current function arg"},
     {"getts", (PyCFunction)tracer_getts, METH_NOARGS, "get timestamp"},
     {"get_base_time", (PyCFunction)tracer_getbasetime, METH_NOARGS, "get base time in nanoseconds"},
+    {"get_pthread_id_map", (PyCFunction)tracer_getpthreadidmap, METH_NOARGS, "get pthread_self() -> SYS_gettid mapping for Kineto thread ID remapping"},
     {"reset_stack", (PyCFunction)tracer_resetstack, METH_NOARGS, "reset stack"},
     {"pause", (PyCFunction)tracer_pause, METH_NOARGS, "pause profiling"},
     {"resume", (PyCFunction)tracer_resume, METH_NOARGS, "resume profiling"},

--- a/src/viztracer/modules/snaptrace.h
+++ b/src/viztracer/modules/snaptrace.h
@@ -90,6 +90,7 @@ struct ThreadInfo {
 struct MetadataNode {
     struct MetadataNode* next;
     unsigned long tid;
+    unsigned long pthread_id;  // `pthread_self()` value for this thread, used to remap Kineto/CUPTI thread IDs
     PyObject* name;
     struct ThreadInfo* thread_info;
 };

--- a/src/viztracer/report_builder.py
+++ b/src/viztracer/report_builder.py
@@ -41,13 +41,48 @@ def get_json(data: dict[str, Any] | str | tuple[str, dict]) -> dict[str, Any]:
             # convert to us
             offset_diff = (torch_offset - base_offset) / 1000
 
+            # See note [pthread-id-for-kineto-remap].
+            # Remap CUPTI thread IDs (`pthread_self()` truncated to `int32_t`)
+            # to `SYS_gettid` values that VizTracer uses.
+            # Our `get_pthread_id_map()` returns unsigned `uint32_t` keys.
+            # Kineto writes `tid` in different formats depending on version:
+            #   - PyTorch <= 2.3: signed `int32_t` (e.g. -780138816)
+            #   - PyTorch >= 2.5: `abs(int32_t)` due to `sanitizeTid()` in
+            #     kineto commit eb1713f ("Prevent Negative TIDs in Trace")
+            # We build a lookup covering all three representations (unsigned,
+            # signed, abs) so the remapping works across PyTorch versions.
+            pthread_id_map: dict[int, int] = args.get('pthread_id_map', {})
+            tid_remap: dict[int, int] = {}
+            for unsigned_key, sys_tid in pthread_id_map.items():
+                signed_key = unsigned_key if unsigned_key < (1 << 31) else unsigned_key - (1 << 32)
+                abs_key = abs(signed_key)
+                tid_remap[unsigned_key] = sys_tid
+                tid_remap[signed_key] = sys_tid
+                tid_remap[abs_key] = sys_tid
+
+            filtered_events = []
             for event in ret['traceEvents']:
                 if 'ts' in event:
                     event['ts'] += offset_diff
+
+                # Remap `tid` from `pthread_self()` to `SYS_gettid`.
+                if 'tid' in event and tid_remap:
+                    tid = event['tid']
+                    if tid in tid_remap:
+                        event['tid'] = tid_remap[tid]
+
                 if event['ph'] == 'M':
                     # Pop metadata timestamp so it won't overwrite
                     # process and thread names
                     event.pop('ts', None)
+                    # Drop thread-name metadata for remapped threads;
+                    # VizTracer already provides correct names.
+                    if event.get('name') == 'thread_name':
+                        tid = event.get('tid')
+                        if tid in pthread_id_map.values():
+                            continue
+                filtered_events.append(event)
+            ret['traceEvents'] = filtered_events
 
             ret.pop("baseTimeNanoseconds", None)
             ret.pop("displayTimeUnit", None)

--- a/src/viztracer/viztracer.py
+++ b/src/viztracer/viztracer.py
@@ -317,9 +317,15 @@ class VizTracer(Tracer):
 
             if self.log_torch and self.torch_profile is not None:
                 import tempfile
+                # See note [pthread-id-for-kineto-remap].
+                pthread_id_map = self.get_pthread_id_map()
                 with tempfile.NamedTemporaryFile(suffix=".json") as tmpfile:
                     self.torch_profile.export_chrome_trace(tmpfile.name)
-                    rb = ReportBuilder([(tmpfile.name, {'type': 'torch', 'base_offset': self.get_base_time()}), self.data],
+                    rb = ReportBuilder([(tmpfile.name, {
+                        'type': 'torch',
+                        'base_offset': self.get_base_time(),
+                        'pthread_id_map': pthread_id_map,
+                    }), self.data],
                                        verbose, minimize_memory=self.minimize_memory, base_time=self.get_base_time())
                     rb.save(output_file=output_file, file_info=file_info)
             else:


### PR DESCRIPTION
Hi, I've been having the problem that with pytorch 2.3.0 with CUDA, `viztracer` `1.1.1` on Python 3.11.

When using CUDA via `pytorch` from 1 Python thread, all is great: I can see (in ui.perfetto.dev) the main thread calling `pytorch` functions, which in turn call torch `aten::` C++ functions, which in turn call `cudaLaunchKernel()` functions, all on the same thread track.

However, when I call CUDA from multiple Python threads (e.g. via `ThreadPoolExecutor`), it goes wrong:

1. The `aten::` functions disappear completely.
    * I am quite sure this is fixed by pytorch 2.4.0 (https://github.com/pytorch/kineto/issues/853, https://github.com/pytorch/pytorch/pull/123650). The issue was loss of precision because Kineto traces used microsecond instead of nanosecond granularity, and the conversion (rounding) caused chat child spans might no longer be contained in their parent spans, making ui.perfetto.dev reject them with parse errors.
2. The `cudaLaunchKernel` etc functions are not shown on the Python thread track they should be on, instead they appear in on a completely separate track (suggesting a separate thread), being disconnected from their Python/C++ callers. This makes reading traces difficult.

For (2), I managed to hack together a workaround, presented in this PR.

Note this was created with the Claude Opus 4.6 LLM; it apparently solves the problem, I read the code and it makes some sense to me, but do take as a caveat that I'm completely new to `viztracer`, `pytorch`, and CUPTI (though I do have general CUDA understanding).

Since I'm not 100% sure this is the correct solution, making this a draft PR.

The screenshot shows the problem with the extra threads:

<img width="472" height="900" alt="image" src="https://github.com/user-attachments/assets/e93af292-2237-4e5f-bcc8-16fb9bf2dfd9" />

And this is what it looks like fixed with my PR doing the remapping, with the extra threads gone:

<img width="571" height="875" alt="image" src="https://github.com/user-attachments/assets/80b14a40-6b46-4fc0-9770-5094c781dbf9" />