### PR TITLE
Fix typos in docs and source comment

### DIFF
--- a/docs/source/viztracer.rst
+++ b/docs/source/viztracer.rst
@@ -317,7 +317,7 @@ VizTracer
         :type: bool
         :value: False
 
-        Whether check the function name before dump. This is useful for dymanically
+        Whether check the function name before dump. This is useful for dynamically
         generated PyMethodDef.
 
     .. py:attribute:: process_name

--- a/src/viztracer/util.py
+++ b/src/viztracer/util.py
@@ -171,7 +171,7 @@ def pid_exists(pid):
         exit_code = ctypes.c_ulong()
         out = kernel32.GetExitCodeProcess(process, ctypes.byref(exit_code))
         kernel32.CloseHandle(process)
-        # nonzero return value means the funtion succeeds
+        # nonzero return value means the function succeeds
         if out:
             if exit_code.value == STILL_ACTIVE:
                 # According to documents of GetExitCodeProcess.


### PR DESCRIPTION
Fix two spelling mistakes found by codespell:

- `dymanically` → `dynamically` in `docs/source/viztracer.rst`
- `funtion` → `function` in `src/viztracer/util.py` (inline comment)

No logic changes.