### PR TITLE
fix: 新增 --exclude_subprocess 参数，用来解决torch.compile等不死子进程导致的死锁

### DIFF
--- a/src/viztracer/main.py
+++ b/src/viztracer/main.py
@@ -283,6 +283,13 @@ class VizUI:
             help="Do not log any process other than the main process",
         )
         parser.add_argument(
+            "--exclude_subprocess",
+            nargs="*",
+            default=None,
+            help="Do not trace subprocesses that contain any of the specified strings "
+                 "in their command line. Useful for subprocesses that never exit.",
+        )
+        parser.add_argument(
             "--magic_comment",
             action="store_true",
             default=False,
@@ -533,6 +540,7 @@ class VizUI:
             "ignore_c_function": options.ignore_c_function,
             "ignore_frozen": options.ignore_frozen,
             "ignore_multiprocess": options.ignore_multiprocess,
+            "exclude_subprocess": options.exclude_subprocess,
             "log_func_retval": options.log_func_retval,
             "log_func_args": options.log_func_args,
             "log_func_with_objprint": options.log_func_with_objprint,

--- a/src/viztracer/patch.py
+++ b/src/viztracer/patch.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
     from .viztracer import VizTracer
 
 
-def patch_subprocess(viz_args: list[str]) -> None:
+def patch_subprocess(viz_args: list[str], exclude_subprocess: list[str] | None = None) -> None:
     import shlex
     import subprocess
 
@@ -30,6 +30,16 @@ def patch_subprocess(viz_args: list[str]) -> None:
     # Note: viztracer doesn't really work in interactive mode and arg handling is weird.
     # Unlikely to be used in practice anyway so we just skip wrapping interactive python processes.
     interactive_pat = re.compile("-[A-Za-z]*?i[A-Za-z]*$")
+
+    def _should_exclude(args: Sequence[str]) -> bool:
+        """Check if the subprocess command should be excluded from tracing."""
+        if not exclude_subprocess:
+            return False
+        cmd_str = " ".join(str(a) for a in args)
+        for pattern in exclude_subprocess:
+            if pattern in cmd_str:
+                return True
+        return False
 
     def build_command(args: Sequence[str]) -> list[str] | None:
         py_args: list[str] = []
@@ -124,7 +134,9 @@ def patch_subprocess(viz_args: list[str]) -> None:
         if isinstance(new_args, str):
             new_args = shlex.split(new_args, posix=sys.platform != "win32")
         if isinstance(new_args, Sequence):
-            if "python" in os.path.basename(new_args[0]):
+            if _should_exclude(new_args):
+                new_args = None
+            elif "python" in os.path.basename(new_args[0]):
                 new_args = build_command(new_args)
             elif is_python_entry(new_args[0]):
                 new_args = [
@@ -361,7 +373,7 @@ def install_all_hooks(tracer: VizTracer) -> None:
     # multiprocess hook
     if not tracer.ignore_multiprocess:
         patch_multiprocessing(tracer, args)
-        patch_subprocess(args)
+        patch_subprocess(args, exclude_subprocess=tracer.exclude_subprocess)
 
     HookManager().set_tracer(tracer)
 

--- a/src/viztracer/viztracer.py
+++ b/src/viztracer/viztracer.py
@@ -63,6 +63,7 @@ class VizTracer(Tracer):
         process_name: str | None = None,
         output_file: str = "result.json",
         plugins: Sequence[VizPluginBase | str] | None = None,
+        exclude_subprocess: list[str] | None = None,
     ) -> None:
         super().__init__(tracer_entries)
 
@@ -100,6 +101,7 @@ class VizTracer(Tracer):
         self.file_info = file_info
         self.log_sparse = log_sparse
         self.log_audit = log_audit
+        self.exclude_subprocess = exclude_subprocess
         self.log_torch = log_torch
         self.ignore_multiprocess = ignore_multiprocess
         self.torch_profile = None

--- a/tests/test_patch.py
+++ b/tests/test_patch.py
@@ -222,3 +222,64 @@ class TestPatchSideEffect(CmdlineTmpl):
             expected_output_file="result.json",
             script=file_after_patch_check,
         )
+
+
+file_exclude_subprocess_tmpl = """
+import subprocess
+import sys
+
+# This subprocess contains the marker and should NOT be traced
+try:
+    output1 = subprocess.check_output(
+        [sys.executable, "-c", "print('__MARKER_EXCLUDED__')"],
+        text=True, timeout=5
+    )
+except subprocess.TimeoutExpired:
+    output1 = "timeout"
+
+# This subprocess does NOT contain the marker and SHOULD be traced
+try:
+    output2 = subprocess.check_output(
+        [sys.executable, "-c", "print('__MARKER_NORMAL__')"],
+        text=True, timeout=5
+    )
+except subprocess.TimeoutExpired:
+    output2 = "timeout"
+
+print(output1.strip())
+print(output2.strip())
+"""
+
+
+class TestExcludeSubprocess(CmdlineTmpl):
+    def test_exclude_subprocess_filters_correctly(self):
+        """Verify that --exclude_subprocess prevents tracing of matching subprocesses."""
+        # Run with exclude_subprocess, the excluded subprocess should not be traced
+        self.template(
+            [
+                sys.executable,
+                "-m",
+                "viztracer",
+                "-o",
+                "result.json",
+                "--exclude_subprocess", 
+                "__MARKER_EXCLUDED__",
+                "--",
+                "cmdline_test.py",
+            ],
+            expected_output_file="result.json",
+            script=file_exclude_subprocess_tmpl,
+            check_func=self._check_excluded,
+        )
+
+    def _check_excluded(self, data):
+        """Verify the trace data is valid and contains expected process events."""
+        self.assertIn("traceEvents", data)
+        # At minimum we should have some trace events from the main process
+        events = data["traceEvents"]
+        self.assertGreater(len(events), 0)
+        # The excluded process marker should NOT appear in any event name
+        event_names = " ".join(
+            e.get("name", "") for e in events if isinstance(e, dict)
+        )
+        self.assertNotIn("__MARKER_EXCLUDED__", event_names)


### PR DESCRIPTION
部分子进程（如PyTorch torch.compile的inductor worker）不会主动退出，而是等待父进程结束后才死亡。当viztracer通过 patch_subprocess将自身注入这类子进程后，ReportServer的collect()循环会无限等待其连接关闭，导致死锁。
本次提交新增--exclude_subprocess选项（同时支持 CLI 和 Python API），允许用户通过命令行子串匹配来排除特定子进程的追踪。被排除的子进程不会被注入viztracer，也不会连接ReportServer。
Closes #583