### PR TITLE
fix tracer thread metadata lifetime

### DIFF
--- a/src/viztracer/modules/snaptrace.c
+++ b/src/viztracer/modules/snaptrace.c
@@ -278,11 +278,11 @@ get_thread_info(TracerObject* self)
 }
 
 static void
-snaptrace_threaddestructor(void* key) {
-    struct ThreadInfo* info = key;
+snaptrace_freethreadinfo(struct ThreadInfo* info) {
+    // ThreadInfo owns Python references, so release it while the tracer is
+    // deallocated with the GIL instead of from an arbitrary TLS destructor.
     struct FunctionNode* tmp = NULL;
     if (info) {
-        PyGILState_STATE state = PyGILState_Ensure();
         info->paused = 0;
         info->curr_stack_depth = 0;
         info->ignore_stack_depth = 0;
@@ -302,9 +302,10 @@ snaptrace_threaddestructor(void* key) {
         info->stack_top = NULL;
         Py_CLEAR(info->curr_task);
         Py_CLEAR(info->curr_task_frame);
-        info->metadata_node->thread_info = NULL;
+        if (info->metadata_node) {
+            info->metadata_node->thread_info = NULL;
+        }
         PyMem_FREE(info);
-        PyGILState_Release(state);
     }
 }
 
@@ -2015,6 +2016,7 @@ Tracer_New(PyTypeObject* type, PyObject* args, PyObject* kwargs)
         self->buffer_tail_idx = 0;
         self->sync_marker = 0;
         self->metadata_head = NULL;
+        self->thread_key_initialized = 0;
     }
 
     return (PyObject*) self;
@@ -2042,11 +2044,12 @@ Tracer_Init(TracerObject* self, PyObject* args, PyObject* kwargs)
         exit(-1);
     }
 #else
-    if (pthread_key_create(&self->thread_key, snaptrace_threaddestructor)) {
+    if (pthread_key_create(&self->thread_key, NULL)) {
         perror("Failed to create Tss_Key");
         exit(-1);
     }
 #endif
+    self->thread_key_initialized = 1;
 
 #if PY_VERSION_HEX >= 0x030C0000
 #else
@@ -2080,10 +2083,20 @@ Tracer_dealloc(TracerObject* self)
     Py_XDECREF(self->exclude_files);
     PyMem_FREE(self->buffer);
 
+    if (self->thread_key_initialized) {
+#if _WIN32
+        TlsFree(self->dwTlsIndex);
+#else
+        pthread_key_delete(self->thread_key);
+#endif
+        self->thread_key_initialized = 0;
+    }
+
     struct MetadataNode* node = self->metadata_head;
     struct MetadataNode* prev = NULL;
     while (node) {
         prev = node;
+        snaptrace_freethreadinfo(node->thread_info);
         Py_CLEAR(node->name);
         node = node->next;
         PyMem_FREE(prev);

--- a/src/viztracer/modules/snaptrace.h
+++ b/src/viztracer/modules/snaptrace.h
@@ -101,6 +101,7 @@ typedef struct {
 #else
     pthread_key_t thread_key;
 #endif
+    int thread_key_initialized;
     int collecting;
     // When we do fork_save(), we want to keep the pid. This is a 
     // mechanism for child process to keep the parent's pid. If 

--- a/tests/test_multithread.py
+++ b/tests/test_multithread.py
@@ -1,6 +1,8 @@
 # Licensed under the Apache License: http://www.apache.org/licenses/LICENSE-2.0
 # For details: https://github.com/gaogaotiantian/viztracer/blob/master/NOTICE.txt
 
+import os
+import subprocess
 import sys
 import threading
 import time
@@ -31,6 +33,41 @@ class MyThreadTraceAware(threading.Thread):
 
 
 class TestMultithread(BaseTmpl):
+    def test_tracer_deallocation_before_worker_thread_exit(self):
+        script = """
+import gc
+import threading
+from viztracer import VizTracer
+
+traced = threading.Event()
+release = threading.Event()
+
+def worker():
+    sum(range(10))
+    traced.set()
+    release.wait()
+
+tracer = VizTracer(verbose=0, register_global=False)
+tracer.start()
+thread = threading.Thread(target=worker)
+thread.start()
+traced.wait()
+tracer.stop()
+del tracer
+gc.collect()
+release.set()
+thread.join()
+"""
+        env = os.environ.copy()
+        env["PYTHONMALLOC"] = "malloc"
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+
     def test_basic(self):
         tracer = VizTracer(max_stack_depth=4, verbose=0)
         tracer.start()


### PR DESCRIPTION
`ThreadInfo` objects currently outlive the tracer through pthread TLS, but point back to tracer-owned `MetadataNode` objects. If the tracer is deallocated before a traced worker thread exits, the TLS destructor later dereferences freed metadata. The destructor also calls `PyGILState_Ensure()`, which is unsafe during interpreter finalization.

This change makes the tracer own its `ThreadInfo` objects for the tracer lifetime, deletes the TLS key during tracer deallocation, and releases Python references while deallocation still holds the GIL. It also covers the worker-outlives-tracer lifecycle in the multithread tests.

This preserves thread metadata while the tracer is usable and removes the late destructor callback into freed tracer state.