### PR TITLE
Don't call into CPython from the thread destructor after finalization

### DIFF
--- a/src/viztracer/modules/snaptrace.c
+++ b/src/viztracer/modules/snaptrace.c
@@ -281,6 +281,15 @@ snaptrace_threaddestructor(void* key) {
     struct ThreadInfo* info = key;
     struct FunctionNode* tmp = NULL;
     if (info) {
+        // A thread can exit after the interpreter is gone -- for example a
+        // native thread pool that outlives Py_FinalizeEx() and is joined by a
+        // C++ static destructor during exit(). There is no interpreter left
+        // for PyGILState_Ensure() to attach to, so it would dereference
+        // torn-down state and segfault. Leak the per-thread buffers instead;
+        // the process is already on its way out.
+        if (Py_IsFinalizing()) {
+            return;
+        }
         PyGILState_STATE state = PyGILState_Ensure();
         info->paused = 0;
         info->curr_stack_depth = 0;

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -659,3 +659,43 @@ class TestThreadingExitOrder(CmdlineTmpl):
             script=threading_exit_order,
             expected_stdout="hello world",
         )
+
+
+class TestThreadDestructorAfterFinalize(CmdlineTmpl):
+    # snaptrace_threaddestructor runs from the TLS destructor when a traced
+    # thread exits, which can be after the interpreter is finalized. It used to
+    # call PyGILState_Ensure() unconditionally and segfault. Daemon threads
+    # still running when the main thread exits reproduce the race.
+    @unittest.skipIf(
+        sys.platform == "win32", "TLS destructor is only registered on POSIX"
+    )
+    def test_thread_exiting_after_finalize(self):
+        thread_destructor_code = """
+            import threading
+            import time
+
+            from viztracer import VizTracer
+
+            def busy():
+                deadline = time.time() + 2.0
+                while time.time() < deadline:
+                    sorted({str(i): [i] for i in range(200)})
+
+            tracer = VizTracer(verbose=0, ignore_c_function=False, ignore_frozen=False)
+            tracer.start()
+            for _ in range(4):
+                threading.Thread(target=busy, daemon=True).start()
+            time.sleep(0.3)
+            tracer.stop()
+            tracer.save()
+            print("saved")
+            """
+        # Whether a worker exits before or after Py_FinalizeEx() is a race, so
+        # repeat to make a reintroduced crash reasonably likely to be caught.
+        for _ in range(10):
+            self.template(
+                [sys.executable, "cmdline_test.py"],
+                script=thread_destructor_code,
+                expected_output_file="result.json",
+                expected_stdout="saved",
+            )


### PR DESCRIPTION

Fixes #687

## Problem

`snaptrace_threaddestructor` is registered as a pthread TLS destructor
(`snaptrace.c:2045`), so it runs whenever a traced thread exits — including
after `Py_FinalizeEx()` has already torn the interpreter down. It then calls
`PyGILState_Ensure()` unconditionally, dereferences interpreter state that no
longer exists, and the process dies with SIGSEGV.

`tracer.stop()`/`tracer.save()` complete normally first, so the trace is written
and the crash only surfaces as a non-zero exit status afterwards.

Two ways to hit it:

- **Racy:** daemon threads still running when the main thread exits. 8 of 30
  runs crash on current `master` with CPython 3.12.13 (6 of 30 on 1.1.1).
- **Deterministic:** a native (C++) thread pool held as a process-lifetime
  `static` that calls `PyGILState_Ensure()` to return results to Python. It is
  joined by the C++ static-destructor chain inside `exit()`, which by
  construction runs after `Py_RunMain()` has already finalized the interpreter,
  so such a thread *always* runs its TLS destructor too late. 6 of 6 runs crash
  in a production service of this shape.

## Fix

Return early if the interpreter is finalizing. `snaptrace.c` already includes
`pythoncapi_compat.h`, which supplies a portable `Py_IsFinalizing()` across all
supported versions, so no version conditional is needed.

The destructor body only does `Py_CLEAR()` / `PyMem_FREE()` on per-thread
buffers, so the early return leaks those buffers microseconds before the process
exits — the only thing that is actually safe to do at that point.

## Verification

| | unpatched | patched |
|---|---|---|
| Minimal daemon-thread repro (`master`) | 8/30 crash | **0/30** |
| Production service, C++ pool (1.1.1) | 6/6 crash | **0/6** |

Tracing is unaffected: trace files are still written (~72 MB, ~566k events,
valid JSON), and the traced application's own output artifact is byte-for-byte
identical (`sha256` match) to an untraced run.

Full suite on this branch: `243 passed, 7 skipped, 2 subtests passed`.
`ruff check` and `ruff format --check` are clean.

## Test

Adds `TestThreadDestructorAfterFinalize` to `tests/test_regression.py`, which
runs the daemon-thread script as a subprocess and asserts a clean exit. Because
whether a worker exits before or after `Py_FinalizeEx()` is a race, it repeats
10 times; with the bug present that gives a high chance of catching it, and with
the fix it is stable. Skipped on Windows, where the TLS destructor is not
registered (`TlsAlloc` branch).
