### PR TITLE
Honor log_func_args/retval in @log_sparse stack_depth=0

### DIFF
--- a/src/viztracer/decorator.py
+++ b/src/viztracer/decorator.py
@@ -2,6 +2,7 @@
 # For details: https://github.com/gaogaotiantian/viztracer/blob/master/NOTICE.txt
 
 import functools
+import inspect
 import multiprocessing
 import os
 import time
@@ -96,6 +97,15 @@ def trace_and_save(
     return inner
 
 
+def _format_func_value(value: Any, log_func_repr: Callable | None) -> str:
+    try:
+        if log_func_repr is not None:
+            return log_func_repr(value)
+        return repr(value)
+    except Exception:
+        return "Not Displayable"
+
+
 def _log_sparse_wrapper(
     func: Callable, stack_depth: int = 0, dynamic_tracer_check: bool = False
 ) -> Callable:
@@ -135,6 +145,19 @@ def _log_sparse_wrapper(
                     "dur": dur,
                     "cat": "FEE",
                 }
+                if local_tracer.log_func_args or local_tracer.log_func_retval:
+                    event_args: dict[str, Any] = {}
+                    fmt = local_tracer.log_func_repr
+                    if local_tracer.log_func_args:
+                        bound = inspect.signature(func).bind(*args, **kwargs)
+                        bound.apply_defaults()
+                        event_args["func_args"] = {
+                            name: _format_func_value(value, fmt)
+                            for name, value in bound.arguments.items()
+                        }
+                    if local_tracer.log_func_retval:
+                        event_args["return_value"] = _format_func_value(ret, fmt)
+                    raw_data["args"] = event_args
                 local_tracer.add_raw(raw_data)
                 return ret
         elif local_tracer.enable and not local_tracer.log_sparse:

--- a/tests/test_logsparse.py
+++ b/tests/test_logsparse.py
@@ -198,6 +198,35 @@ class TestLogSparse(CmdlineTmpl):
             expected_output_file="result.json",
         )
 
+    def test_log_func_args_retval(self):
+        from viztracer import VizTracer, log_sparse
+
+        tracer = VizTracer(
+            log_sparse=True,
+            log_func_args=True,
+            log_func_retval=True,
+            verbose=0,
+        )
+
+        @log_sparse
+        def f(x):
+            return x * x
+
+        self.assertEqual(f(3), 9)
+        tracer.parse()
+        events = [
+            e
+            for e in tracer.data["traceEvents"]
+            if e.get("ph") == "X" and e["name"].startswith("f ")
+        ]
+        self.assertEqual(len(events), 1)
+        args = events[0].get("args") or {}
+        self.assertIn("func_args", args)
+        self.assertIn("x", args["func_args"])
+        self.assertEqual(args["func_args"]["x"], "3")
+        self.assertIn("return_value", args)
+        self.assertEqual(args["return_value"], "9")
+
     def test_stack(self):
         self.template(
             ["viztracer", "-o", "result.json", "--log_sparse", "cmdline_test.py"],


### PR DESCRIPTION
`@log_sparse` with the default `stack_depth=0` builds a Chrome-trace duration event in Python and never copied the tracer's `log_func_args` / `log_func_retval` flags onto it. The `stack_depth>0` path starts the C tracer, which already records `args["func_args"]` and `args["return_value"]`. So `VizTracer(log_sparse=True, log_func_args=True, log_func_retval=True)` plus `@log_sparse def f(x): return x*x` only stored duration.

After the call in the `stack_depth=0` branch, bind `*args/**kwargs` to the function parameter names and attach `repr` (or `log_func_repr`) the same way snaptrace does. The C tracer is not started for this path.

Reported by @Guation.

Fixes #685