### PR TITLE
Fix attach binary selection for cross-built wheels

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,7 @@ include LICENSE
 include NOTICE.txt
 include README.md
 include setup.py
+include setup_helpers.py
 
 recursive-include src/viztracer/html *.css *.js
 recursive-include src/viztracer/modules *.c *.h

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,65 @@
+import os
 import platform
 import sys
 
 import setuptools
+from setuptools.command.build_py import build_py as _build_py
+
+from setup_helpers import get_linux_attach_binary
+
+_LINUX_ATTACH_BINARIES = {
+    "attach_process/attach_linux_amd64.so",
+    "attach_process/attach_linux_x86.so",
+}
+_LINUX_ATTACH_BINARY_NAMES = {
+    os.path.basename(binary) for binary in _LINUX_ATTACH_BINARIES
+}
+_NO_TARGET_PLATFORM = object()
+
+
+class build_py(_build_py):
+    """Copy only the Linux attach binary matching the wheel target."""
+
+    def initialize_options(self) -> None:
+        super().initialize_options()
+        self._target_attach_binary = _NO_TARGET_PLATFORM
+
+    def _set_target_attach_binary(self) -> None:
+        bdist_wheel = self.distribution.get_command_obj("bdist_wheel", create=False)
+        if bdist_wheel is None:
+            self._target_attach_binary = _NO_TARGET_PLATFORM
+        else:
+            bdist_wheel.ensure_finalized()
+            self._target_attach_binary = get_linux_attach_binary(bdist_wheel.plat_name)
+
+    def run(self) -> None:
+        self._set_target_attach_binary()
+        self.__dict__.pop("data_files", None)
+        super().run()
+
+    def find_data_files(self, package: str, src_dir: str) -> list[str]:
+        self._set_target_attach_binary()
+        files = super().find_data_files(package, src_dir)
+        is_viztracer_package = package == "viztracer" or package.startswith(
+            "viztracer."
+        )
+        if (
+            not is_viztracer_package
+            or self._target_attach_binary is _NO_TARGET_PLATFORM
+        ):
+            return files
+
+        files = [
+            file
+            for file in files
+            if os.path.basename(file) not in _LINUX_ATTACH_BINARY_NAMES
+        ]
+        if package == "viztracer" and self._target_attach_binary:
+            binary = os.path.join(src_dir, self._target_attach_binary)
+            if os.path.isfile(binary):
+                files.append(binary)
+        return files
+
 
 # Determine which attach binary to take into package
 package_data = {
@@ -53,6 +111,7 @@ setuptools.setup(
     packages=setuptools.find_namespace_packages("src"),
     package_dir={"": "src"},
     package_data=package_data,
+    cmdclass={"build_py": build_py},
     ext_modules=[
         setuptools.Extension(
             "viztracer.snaptrace",

--- a/setup_helpers.py
+++ b/setup_helpers.py
@@ -1,0 +1,24 @@
+"""Helpers shared by the package build configuration and its tests."""
+
+
+def get_linux_attach_binary(plat_name: str | None) -> str | None:
+    """Return the Linux attach binary for a wheel platform name.
+
+    ``plat_name`` is the target platform embedded in a wheel name. It can
+    differ from the platform running the build, for example when a package is
+    cross-built. Unknown platforms intentionally return no binary instead of
+    guessing which architecture is compatible.
+    """
+
+    if not plat_name:
+        return None
+
+    normalized = plat_name.lower().replace("-", "_").replace(".", "_")
+    if not normalized.startswith(("linux_", "manylinux", "musllinux")):
+        return None
+
+    if normalized.endswith(("x86_64", "amd64")):
+        return "attach_process/attach_linux_amd64.so"
+    if normalized.endswith(("i686", "i386", "x86")):
+        return "attach_process/attach_linux_x86.so"
+    return None

--- a/tests/test_setup_helpers.py
+++ b/tests/test_setup_helpers.py
@@ -1,0 +1,29 @@
+import unittest
+
+from setup_helpers import get_linux_attach_binary
+
+
+class TestLinuxAttachBinary(unittest.TestCase):
+    def test_x86_64_platform(self):
+        self.assertEqual(
+            get_linux_attach_binary("manylinux_2_17_x86_64"),
+            "attach_process/attach_linux_amd64.so",
+        )
+
+    def test_aarch64_platform(self):
+        self.assertIsNone(get_linux_attach_binary("manylinux2014_aarch64"))
+
+    def test_i686_platform(self):
+        self.assertEqual(
+            get_linux_attach_binary("linux_i686"),
+            "attach_process/attach_linux_x86.so",
+        )
+
+    def test_non_linux_platform(self):
+        self.assertIsNone(get_linux_attach_binary("win_amd64"))
+
+    def test_no_platform(self):
+        self.assertIsNone(get_linux_attach_binary(None))
+
+    def test_unknown_platform(self):
+        self.assertIsNone(get_linux_attach_binary("linux_ppc64le"))


### PR DESCRIPTION
## Summary

- select the Linux attach helper from the wheel target platform instead of the build host
- exclude x86-only attach helpers from non-x86 wheels, including wheels built from an sdist
- preserve direct-build behavior and add platform-selection regression tests

## Testing

- `python3.11 -m unittest -v tests.test_setup_helpers`
- `uvx --offline ruff check setup.py setup_helpers.py tests/test_setup_helpers.py`
- `uvx --offline ruff format --check setup.py setup_helpers.py tests/test_setup_helpers.py`
- built clean source and sdist wheels for `linux_aarch64` and `linux_x86_64`; aarch64 contains no Linux attach helper, while x86_64 contains only `attach_linux_amd64.so`
- verified a direct host build still includes the AMD64 helper

Addresses the binary packaging part of #682.